### PR TITLE
changed authinfo comparison from nil to empty struct

### DIFF
--- a/utils/http/http.go
+++ b/utils/http/http.go
@@ -121,7 +121,7 @@ func (httpOptions *HttpOptions) addHeaderTo(request *http.Request) {
 }
 
 func (httpOptions *HttpOptions) addAuthTo(request *http.Request) error {
-	if httpOptions.Auth == nil {
+	if (cacao.AuthenticationInformation{}) == *httpOptions.Auth {
 		return nil
 	}
 	if err := verifyAuthInfoMatchesAgentTarget(httpOptions.Target, httpOptions.Auth); err != nil {

--- a/utils/http/http.go
+++ b/utils/http/http.go
@@ -121,6 +121,9 @@ func (httpOptions *HttpOptions) addHeaderTo(request *http.Request) {
 }
 
 func (httpOptions *HttpOptions) addAuthTo(request *http.Request) error {
+	if httpOptions.Auth == nil {
+		return nil
+	}
 	if (cacao.AuthenticationInformation{}) == *httpOptions.Auth {
 		return nil
 	}


### PR DESCRIPTION
The addAuthTo function in utils/http/http.go performs a check of httpOptions.Auth to be nil, as to check whether it was specified or not, for authentication information is an optional property.

But, an Authentication information should always be passed as property to the capability.Execute() function, hence it is always a struct: either completely empty, or not.

As a consequence, the check in utils/http/http.go addAuthTo is not correct, and the logic further checks for consistency in the field of an empty struct to add authInfo to the headers. This obviously fails, whereas instead it should not be checked, as no auth headers should be added if an empty authInfo struct is passed.