### PR TITLE
Use NewVariables

### DIFF
--- a/internal/capability/http/http.go
+++ b/internal/capability/http/http.go
@@ -44,7 +44,7 @@ func (httpCapability *HttpCapability) Execute(
 	method, url, errmethod := ObtainHttpMethodAndUrlFromCommand(command)
 	if errmethod != nil {
 		log.Error(errmethod)
-		return cacao.Variables{}, errmethod
+		return cacao.NewVariables(), errmethod
 	}
 	content_data, errcontent := ObtainHttpRequestContentDataFromCommand(command)
 	if errcontent != nil {
@@ -56,7 +56,7 @@ func (httpCapability *HttpCapability) Execute(
 	request, err := http.NewRequest(method, url, bytes.NewBuffer(content_data))
 	if err != nil {
 		log.Error(err)
-		return cacao.Variables{}, err
+		return cacao.NewVariables(), err
 	}
 
 	for key, httpCapability := range command.Headers {
@@ -65,12 +65,12 @@ func (httpCapability *HttpCapability) Execute(
 	if target.ID != "" {
 		if err := verifyAuthInfoMatchesAgentTarget(&target, &authentication); err != nil {
 			log.Error(err)
-			return cacao.Variables{}, err
+			return cacao.NewVariables(), err
 		}
 
 		if err := setupAuthHeaders(request, &authentication); err != nil {
 			log.Error(err)
-			return cacao.Variables{}, err
+			return cacao.NewVariables(), err
 		}
 	}
 
@@ -79,23 +79,22 @@ func (httpCapability *HttpCapability) Execute(
 	response, err := client.Do(request)
 	if err != nil {
 		log.Error(err)
-		return cacao.Variables{}, err
+		return cacao.NewVariables(), err
 	}
 	defer response.Body.Close()
 
 	responseBytes, err := io.ReadAll(response.Body)
 	if err != nil {
 		log.Error(err)
-		return cacao.Variables{}, err
+		return cacao.NewVariables(), err
 	}
 	respString := string(responseBytes)
 	sc := response.StatusCode
 	if sc < 200 || sc > 299 {
-		return cacao.Variables{}, errors.New(respString)
+		return cacao.NewVariables(), errors.New(respString)
 	}
 
-	return cacao.Variables{
-		"__soarca_http_result__": {Name: "result", Value: respString}}, nil
+	return cacao.NewVariables(cacao.Variable{Name: "__soarca_http_result__", Value: respString}), nil
 
 }
 

--- a/internal/capability/ssh/ssh.go
+++ b/internal/capability/ssh/ssh.go
@@ -40,7 +40,7 @@ func (sshCapability *SshCapability) Execute(metadata execution.Metadata,
 
 	if errAuth != nil {
 		log.Error(errAuth)
-		return cacao.Variables{}, errAuth
+		return cacao.NewVariables(), errAuth
 	} else {
 		log.Trace(host)
 	}
@@ -60,7 +60,7 @@ func (sshCapability *SshCapability) Execute(metadata execution.Metadata,
 		signer, errKey := ssh.ParsePrivateKey([]byte(authentication.PrivateKey))
 		if errKey != nil || authentication.Password == "" {
 			log.Error("no valid authentication information: ", errKey)
-			return cacao.Variables{}, errKey
+			return cacao.NewVariables(), errKey
 		}
 		config = ssh.ClientConfig{
 			User: authentication.Username,
@@ -78,13 +78,13 @@ func (sshCapability *SshCapability) Execute(metadata execution.Metadata,
 	conn, err := ssh.Dial("tcp", host, &config)
 	if err != nil {
 		log.Error(err)
-		return cacao.Variables{}, err
+		return cacao.NewVariables(), err
 	}
 	var session *ssh.Session
 	session, err = conn.NewSession()
 	if err != nil {
 		log.Error(err)
-		return cacao.Variables{}, err
+		return cacao.NewVariables(), err
 	}
 
 	response, err := session.Output(StripSshPrepend(command.Command))
@@ -92,9 +92,9 @@ func (sshCapability *SshCapability) Execute(metadata execution.Metadata,
 
 	if err != nil {
 		log.Error(err)
-		return cacao.Variables{"__soarca_ssh_result__": {Name: "result", Value: string(response)}}, err
+		return cacao.NewVariables(), err
 	}
-	results := cacao.Variables{"__soarca_ssh_result__": {Name: "result", Value: string(response)}}
+	results := cacao.NewVariables(cacao.Variable{Name: "__soarca_ssh_result__", Value: string(response)})
 	log.Trace("Finished ssh execution will return the variables: ", results)
 	return results, err
 }

--- a/internal/executer/executer.go
+++ b/internal/executer/executer.go
@@ -50,7 +50,7 @@ func (executer *Executer) Execute(metadata execution.Metadata,
 		returnVariables, err := capability.Execute(metadata, command, authentication, target, variable)
 		return metadata.ExecutionId, returnVariables, err
 	} else {
-		empty := cacao.Variables{}
+		empty := cacao.NewVariables()
 		message := "executor is not available in soarca"
 		err := errors.New(message)
 		log.Error(message)

--- a/test/integration/capability/http/http_integration_test.go
+++ b/test/integration/capability/http/http_integration_test.go
@@ -35,7 +35,7 @@ func TestHttpConnection(t *testing.T) {
 		metadata, expectedCommand,
 		cacao.AuthenticationInformation{},
 		cacao.AgentTarget{},
-		cacao.Variables{"test": variable1})
+		cacao.NewVariables(variable1))
 	if err != nil {
 		fmt.Println(err)
 		t.Fail()
@@ -81,7 +81,7 @@ func TestHttpOAuth2(t *testing.T) {
 		expectedCommand,
 		oauth2_info,
 		target,
-		cacao.Variables{"test": variable1})
+		cacao.NewVariables(variable1))
 	if err != nil {
 		fmt.Println(err)
 		t.Fail()
@@ -125,7 +125,8 @@ func TestHttpBasicAuth(t *testing.T) {
 		metadata,
 		expectedCommand,
 		basicauth_info,
-		target, cacao.Variables{"test": variable1})
+		target,
+		cacao.NewVariables(variable1))
 	if err != nil {
 		fmt.Println(err)
 		t.Fail()

--- a/test/integration/capability/ssh/ssh_integration_test.go
+++ b/test/integration/capability/ssh/ssh_integration_test.go
@@ -45,7 +45,7 @@ func TestSshConnection(t *testing.T) {
 		expectedCommand,
 		expectedAuthenticationInformation,
 		expectedTarget,
-		cacao.Variables{expectedVariables.Name: expectedVariables})
+		cacao.NewVariables(expectedVariables))
 	if err != nil {
 		fmt.Println(err)
 		t.Fail()

--- a/test/unittest/cacao/variables_test.go
+++ b/test/unittest/cacao/variables_test.go
@@ -7,6 +7,17 @@ import (
 	"github.com/go-playground/assert/v2"
 )
 
+func TestNewVariables(t *testing.T) {
+	variable := cacao.Variable{
+		Type:  "string",
+		Name:  "variable 1",
+		Value: "value 1",
+	}
+	variables := cacao.NewVariables(variable)
+	expected := cacao.Variables{"variable 1": variable}
+	assert.Equal(t, variables, expected)
+}
+
 func TestVariablesFind(t *testing.T) {
 	variables := make(cacao.Variables)
 	inserted := cacao.Variable{

--- a/test/unittest/decomposer/decomposer_test.go
+++ b/test/unittest/decomposer/decomposer_test.go
@@ -36,7 +36,7 @@ func TestExecutePlaybook(t *testing.T) {
 		Type:          "ssh",
 		ID:            "action--test",
 		Name:          "ssh-tests",
-		StepVariables: cacao.Variables{expectedVariables.Name: expectedVariables},
+		StepVariables: cacao.NewVariables(expectedVariables),
 		Commands:      []cacao.Command{expectedCommand},
 		Cases:         map[string]string{},
 		OnCompletion:  "end--test",
@@ -85,8 +85,8 @@ func TestExecutePlaybook(t *testing.T) {
 	mock_executer.On("Execute", metaStep1, expectedCommand,
 		expectedAuth,
 		expectedTarget,
-		cacao.Variables{"var1": expectedVariables},
-		expectedAgent).Return(executionId, cacao.Variables{}, nil)
+		cacao.NewVariables(expectedVariables),
+		expectedAgent).Return(executionId, cacao.NewVariables(), nil)
 
 	returnedId, err := decomposer.Execute(playbook)
 	uuid_mock.AssertExpectations(t)
@@ -129,7 +129,7 @@ func TestExecutePlaybookMultiStep(t *testing.T) {
 		Type:          "ssh",
 		ID:            "action--test",
 		Name:          "ssh-tests",
-		StepVariables: cacao.Variables{expectedVariables.Name: expectedVariables},
+		StepVariables: cacao.NewVariables(expectedVariables),
 		Commands:      []cacao.Command{expectedCommand},
 		Cases:         map[string]string{},
 		OnCompletion:  "action--test2",
@@ -142,7 +142,7 @@ func TestExecutePlaybookMultiStep(t *testing.T) {
 		Type:          "ssh",
 		ID:            "action--test2",
 		Name:          "ssh-tests",
-		StepVariables: cacao.Variables{expectedVariables2.Name: expectedVariables2},
+		StepVariables: cacao.NewVariables(expectedVariables2),
 		Commands:      []cacao.Command{expectedCommand2},
 		Cases:         map[string]string{},
 		Agent:         "agent1",
@@ -153,7 +153,7 @@ func TestExecutePlaybookMultiStep(t *testing.T) {
 		Type:          "ssh",
 		ID:            "action--test3",
 		Name:          "ssh-tests",
-		StepVariables: cacao.Variables{expectedVariables.Name: expectedVariables},
+		StepVariables: cacao.NewVariables(expectedVariables2),
 		Commands:      []cacao.Command{expectedCommand},
 		Agent:         "agent1",
 		// Targets:       []string{"target1"},
@@ -200,15 +200,15 @@ func TestExecutePlaybookMultiStep(t *testing.T) {
 		expectedCommand,
 		expectedAuth,
 		expectedTarget,
-		cacao.Variables{"var1": expectedVariables},
-		expectedAgent).Return(executionId, cacao.Variables{}, nil)
+		cacao.NewVariables(expectedVariables),
+		expectedAgent).Return(executionId, cacao.NewVariables(), nil)
 
 	mock_executer.On("Execute", metaStep2,
 		expectedCommand2,
 		expectedAuth,
 		expectedTarget,
-		cacao.Variables{"var2": expectedVariables2},
-		expectedAgent).Return(executionId, cacao.Variables{}, nil)
+		cacao.NewVariables(expectedVariables2),
+		expectedAgent).Return(executionId, cacao.NewVariables(), nil)
 
 	returnedId, err := decomposer.Execute(playbook)
 	uuid_mock.AssertExpectations(t)
@@ -255,7 +255,7 @@ func TestExecuteEmptyMultiStep(t *testing.T) {
 		ID:            "action--test",
 		Name:          "ssh-tests",
 		Agent:         "agent1",
-		StepVariables: cacao.Variables{expectedVariables.Name: expectedVariables},
+		StepVariables: cacao.NewVariables(expectedVariables),
 		Commands:      []cacao.Command{expectedCommand},
 		Cases:         map[string]string{},
 		OnCompletion:  "",
@@ -307,7 +307,7 @@ func TestExecuteIllegalMultiStep(t *testing.T) {
 		Type:          "ssh",
 		ID:            "action--test",
 		Name:          "ssh-tests",
-		StepVariables: cacao.Variables{expectedVariables.Name: expectedVariables},
+		StepVariables: cacao.NewVariables(expectedVariables),
 		Commands:      []cacao.Command{expectedCommand},
 		Cases:         map[string]string{},
 		OnCompletion:  "action-some-non-existing",

--- a/test/unittest/executor/executor_test.go
+++ b/test/unittest/executor/executor_test.go
@@ -56,15 +56,15 @@ func TestExecuteStep(t *testing.T) {
 		expectedCommand,
 		expectedAuth,
 		expectedTarget,
-		cacao.Variables{expectedVariables.Name: expectedVariables}).
-		Return(cacao.Variables{expectedVariables.Name: expectedVariables},
+		cacao.NewVariables(expectedVariables)).
+		Return(cacao.NewVariables(expectedVariables),
 			nil)
 
 	_, _, err := executerObject.Execute(metadata,
 		expectedCommand,
 		expectedAuth,
 		expectedTarget,
-		cacao.Variables{expectedVariables.Name: expectedVariables},
+		cacao.NewVariables(expectedVariables),
 		agent)
 
 	assert.Equal(t, err, nil)
@@ -113,7 +113,7 @@ func TestNonExistingCapabilityStep(t *testing.T) {
 		expectedCommand,
 		expectedAuth,
 		expectedTarget,
-		cacao.Variables{expectedVariables.Name: expectedVariables},
+		cacao.NewVariables(expectedVariables),
 		agent)
 
 	assert.Equal(t, err, errors.New("executor is not available in soarca"))


### PR DESCRIPTION
Uses NewVariables and corrects the `Name` of returned variables from executor capabilities.