### PR TITLE
Use consistent capability naming

### DIFF
--- a/internal/capability/http/http.go
+++ b/internal/capability/http/http.go
@@ -18,6 +18,11 @@ import (
 // Run HTTP API call
 // Return response
 
+const (
+	httpApiResultVariableName = "__soarca_http_api_result__"
+	httpApiCapabilityName     = "soarca-http-api"
+)
+
 type HttpCapability struct {
 }
 
@@ -31,7 +36,7 @@ func init() {
 }
 
 func (httpCapability *HttpCapability) GetType() string {
-	return "soarca-http-api"
+	return httpApiCapabilityName
 }
 
 // What to do if there is no agent or target?
@@ -97,7 +102,7 @@ func (httpCapability *HttpCapability) Execute(
 		return cacao.NewVariables(), errors.New(respString)
 	}
 
-	return cacao.NewVariables(cacao.Variable{Name: "__soarca_http_result__", Value: respString}), nil
+	return cacao.NewVariables(cacao.Variable{Name: httpApiResultVariableName, Value: respString}), nil
 
 }
 

--- a/internal/capability/openc2/openc2.go
+++ b/internal/capability/openc2/openc2.go
@@ -17,7 +17,7 @@ type Empty struct{}
 
 const (
 	openc2ResultVariableName = "__soarca_openc2_http_result__"
-	openc2capabilityName     = "soarca-openc2-http"
+	openc2CapabilityName     = "soarca-openc2-http"
 )
 
 var (
@@ -34,7 +34,7 @@ func New(httpRequest http.IHttpRequest) *OpenC2Capability {
 }
 
 func (OpenC2Capability *OpenC2Capability) GetType() string {
-	return openc2capabilityName
+	return openc2CapabilityName
 }
 
 func (OpenC2Capability *OpenC2Capability) Execute(

--- a/internal/capability/ssh/ssh.go
+++ b/internal/capability/ssh/ssh.go
@@ -13,6 +13,11 @@ import (
 	"golang.org/x/crypto/ssh"
 )
 
+const (
+	sshResultVariableName = "__soarca_ssh_result__"
+	sshCapabilityName     = "soarca-ssh"
+)
+
 type SshCapability struct {
 }
 
@@ -24,7 +29,7 @@ func init() {
 }
 
 func (sshCapability *SshCapability) GetType() string {
-	return "soarca-ssh-capability"
+	return sshCapabilityName
 }
 
 func (sshCapability *SshCapability) Execute(metadata execution.Metadata,
@@ -94,7 +99,7 @@ func (sshCapability *SshCapability) Execute(metadata execution.Metadata,
 		log.Error(err)
 		return cacao.NewVariables(), err
 	}
-	results := cacao.NewVariables(cacao.Variable{Name: "__soarca_ssh_result__", Value: string(response)})
+	results := cacao.NewVariables(cacao.Variable{Name: sshResultVariableName, Value: string(response)})
 	log.Trace("Finished ssh execution will return the variables: ", results)
 	return results, err
 }

--- a/test/unittest/decomposer/decomposer_test.go
+++ b/test/unittest/decomposer/decomposer_test.go
@@ -62,7 +62,7 @@ func TestExecutePlaybook(t *testing.T) {
 
 	expectedAgent := cacao.AgentTarget{
 		Type: "soarca",
-		Name: "soarca-ssh-capability",
+		Name: "soarca-ssh",
 	}
 
 	playbook := cacao.Playbook{
@@ -175,7 +175,7 @@ func TestExecutePlaybookMultiStep(t *testing.T) {
 
 	expectedAgent := cacao.AgentTarget{
 		Type: "soarca",
-		Name: "soarca-ssh-capability",
+		Name: "soarca-ssh",
 	}
 
 	playbook := cacao.Playbook{
@@ -245,7 +245,7 @@ func TestExecuteEmptyMultiStep(t *testing.T) {
 
 	expectedAgent := cacao.AgentTarget{
 		Type: "soarca",
-		Name: "soarca-ssh-capability",
+		Name: "soarca-ssh",
 	}
 
 	decomposer2 := decomposer.New(mock_executer2, uuid_mock2)


### PR DESCRIPTION
SSH was still using the `-capability` suffix. Also bring code in line with openc2 which uses constant instead of magic strings.