### PR TITLE
Improved documentation 

### DIFF
--- a/docs/content/en/docs/contribution-guidelines/_index.md
+++ b/docs/content/en/docs/contribution-guidelines/_index.md
@@ -24,7 +24,7 @@ If there's something you'd like to see in SOARCA (or if you've found something t
 
 
 {{% alert title="Security issues" color="warning" %}}
-For security issues, we kindly request that you refrain from reporting them using the issue tracker. Instead, please contact us directly: [slack](https://cossas.slack.com/archives/C06L65375TN)
+For security issues, we kindly request that you refrain from reporting them using the issue tracker. Instead, please contact us directly: [slack](https://join.slack.com/t/cossas/shared_invite/zt-2i4zxg0oh-dhhL4zTSX5olysngrPxDkg)
 {{% /alert %}}
 
 
@@ -58,7 +58,7 @@ The project has opted to select the [go style guide](https://google.github.io/st
 
 Feel free to engage with the community for discussions and assistance via one of the following channels:
 
-- [slack](https://cossas.slack.com/archives/C06L65375TN)
+- [slack](https://join.slack.com/t/cossas/shared_invite/zt-2i4zxg0oh-dhhL4zTSX5olysngrPxDkg)
 - [GitHub discussions](https://github.com/COSSAS/SOARCA/discussions)
 
 ## Contributing to these docs

--- a/docs/content/en/docs/contribution-guidelines/code_of_conduct.md
+++ b/docs/content/en/docs/contribution-guidelines/code_of_conduct.md
@@ -39,7 +39,7 @@ This Code of Conduct applies both within project spaces and in public spaces whe
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at [insert project email]. All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team via [Github](https://github.com/COSSAS/SOARCA) or join our [Slack](https://cossas.slack.com/join/shared_invite/zt-2i4zxg0oh-dhhL4zTSX5olysngrPxDkg#/shared-invite/email) channel. All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
 
 Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.
 

--- a/docs/content/en/docs/core-components/api-design.md
+++ b/docs/content/en/docs/core-components/api-design.md
@@ -69,7 +69,7 @@ When the caller does not have valid authentication 401/unauthorized will be retu
 @startjson
 {
             "type": "playbook",
-            "spec_version": "1.1",
+            "spec_version": "cacao-2.0",
             "id": "playbook--91220064-3c6f-4b58-99e9-196e64f9bde7",
             "name": "coa flow",
             "description": "This playbook will trigger a specific coa",
@@ -446,7 +446,7 @@ Get all running playbooks
 {
             "playbooks": [
                 {"type": "playbook",
-                "spec_version": "1.1",
+                "spec_version": "cacao-2.0",
                 "id": "playbook--91220064-3c6f-4b58-99e9-196e64f9bde7",
                 "name": "SOARCA Main Flow",
                 "description": "This playbook will run for each trigger event in SOARCA",

--- a/docs/content/en/docs/core-components/modules.md
+++ b/docs/content/en/docs/core-components/modules.md
@@ -22,7 +22,7 @@ The capability will be selected based on the agent in the CACAO playbook step. T
 
 This capability executes [SSH Commands](https://docs.oasis-open.org/cacao/security-playbooks/v2.0/cs01/security-playbooks-v2.0-cs01.html#_Toc152256500) on the specified targets.
 
-This capability support [User Authentication](https://docs.oasis-open.org/cacao/security-playbooks/v2.0/cs01/security-playbooks-v2.0-cs01.html#_Toc152256508) using the `user-auth` type. Both username/password and username/privatekey authentication are supported.
+This capability support [User Authentication](https://docs.oasis-open.org/cacao/security-playbooks/v2.0/cs01/security-playbooks-v2.0-cs01.html#_Toc152256508) using the `user-auth` type. For SSH authentication username/password is authentication supported.
 
 #### Success and failure
 

--- a/docs/content/en/docs/getting-started/_index.md
+++ b/docs/content/en/docs/getting-started/_index.md
@@ -86,13 +86,18 @@ MONGODB_URI: "mongodb://localhost:27017"
 DATABASE_NAME: "soarca"
 DB_USERNAME: "root"
 DB_PASSWORD: "rootpassword"
-WORKFLOW_API_LOG_LEVEL: trace
+PLAYBOOK_API_LOG_LEVEL: trace
 DATABASE: "false"
+MAX_REPORTERS: "5"
 
 LOG_GLOBAL_LEVEL: "info"
 LOG_MODE: "development"
 LOG_FILE_PATH: ""
 LOG_FORMAT: "json"
+
+ENABLE_FINS: false
+MQTT_BROKER: "localhost"
+MQTT_PORT: 1883
 {{< /tab >}}
 {{< /tabpane >}}
 

--- a/docs/content/en/docs/soarca-extensions/_index.md
+++ b/docs/content/en/docs/soarca-extensions/_index.md
@@ -19,7 +19,7 @@ SOARCA features a set of [native capabilities](/docs/soarca-extensions/native-ca
 
 The native capabilities supported by SOARCA can be extended through a mechanism we named Fins. Your capability can be integrated with SOARCA by implementing the Fin protocol. This protocol regulates communication between SOARCA and the extension capabilities over an MQTT bus.
 
-MQTT is a lightweight messaging protocol with libraries written in various programming languages. To integrate with SOARCA, you can write your own implementation of the Fin protocol, or use our [python]() or [golang]() libraries for easier integration.
+MQTT is a lightweight messaging protocol with libraries written in various programming languages. To integrate with SOARCA, you can write your own implementation of the Fin protocol, or use our [python](https://www.python.org/) or [golang](https://go.dev/) libraries for easier integration.
 
 ## Fin protocol
 

--- a/docs/hugo.toml
+++ b/docs/hugo.toml
@@ -111,7 +111,7 @@ version = "0.0"
 url_latest_version = "https://cossas.github.io/SOARCA/docs/"
 
 # Repository configuration (URLs for in-page links to opening issues and suggesting changes)
-github_repo = "https://github.com/COSSAS/SOARCA/issues"
+github_repo = "https://github.com/COSSAS/SOARCA/"
 # An optional link to a related project repo. For example, the sibling repository where your product code lives.
 github_project_repo = "https://github.com/COSSAS/SOARCA/"
 

--- a/docs/hugo.toml
+++ b/docs/hugo.toml
@@ -187,7 +187,7 @@ enable = false
   desc = "Development takes place here!"
 [[params.links.developer]]
   name = "Slack"
-  url = "https://cossas.slack.com/archives/C06L65375TN"
+  url = "https://join.slack.com/t/cossas/shared_invite/zt-2i4zxg0oh-dhhL4zTSX5olysngrPxDkg"
   icon = "fab fa-slack"
   desc = "Chat with other project developers"
 # [[params.links.developer]]


### PR DESCRIPTION
## Impove documentation
fixes for feedback described below and in issue: https://github.com/COSSAS/SOARCA/issues/87




 - [x]   https://cossas.github.io/SOARCA/docs/core-components/api-design/ - “cacao playbook JSON” & “GET /status/playbook”: presents the CACAO v1.1 (instead of CACAO v2)
 - [x]  Few URLs are resolving to the main page instead of the dedicated website. (E.g., fin ref for python and go in https://cossas.github.io/SOARCA/docs/soarca-extensions/)
 - [x] https://cossas.github.io/SOARCA/docs/core-components/modules/ - SSH capability: states the support for “private key” authentication. (The correct name is “public key” authentication. Nevertheless, CACAO v2 does not have that capability)
- [x] Inconsistency between two pages regarding soarca agent type:   https://cossas.github.io/SOARCA/docs/core-components/executer/ - Native capabilities: “... The convention is that the agent type must equal soarca-, e.g. soarca-ssh or soarca-openc2-http.”
- [x]  https://cossas.github.io/SOARCA/docs/core-components/modules/ - Native modules in SOARCA: “... The agent should be of type soarca and have a name corresponding to soarca-[capability name].”
- [x] Add HTTP_SKIP_CERT_VALIDATION env file to env file description
- [x] Code of conduct email fix -> now empty
- [x] Link to slack needs to be updated
