### PR TITLE
handle specific check for case agent-target address is url

### DIFF
--- a/test/unittest/utils/http/http_test.go
+++ b/test/unittest/utils/http/http_test.go
@@ -470,6 +470,32 @@ func TestHttpPathParser(t *testing.T) {
 	assert.Equal(t, parsedUrl, "https://godcapability.tno.nl")
 }
 
+func TestHttpPathUrlComposition(t *testing.T) {
+	target := cacao.AgentTarget{
+		Address: map[cacao.NetAddressType][]string{
+			"url": {"https://godcapability.tno.nl/isp"},
+		},
+	}
+
+	command := cacao.Command{
+		Type:    "http-api",
+		Command: "POST /isp/cst HTTP/1.1",
+		Headers: map[string][]string{"accept": {"application/json"}},
+	}
+	httpOptions := http.HttpOptions{
+		Target:  &target,
+		Command: &command,
+	}
+
+	parsedUrl, err := httpOptions.ExtractUrl()
+	if err != nil {
+		t.Error("failed test because: ", err)
+	}
+	// Duplication of path values if present is INTENDED behaviour and
+	// a warning will be issued
+	assert.Equal(t, parsedUrl, "https://godcapability.tno.nl/isp/isp/cst")
+}
+
 func TestHttpPathBreakingParser(t *testing.T) {
 	target := cacao.AgentTarget{
 		Address: map[cacao.NetAddressType][]string{

--- a/utils/http/http.go
+++ b/utils/http/http.go
@@ -204,7 +204,7 @@ func (httpOptions *HttpOptions) ExtractUrl() (string, error) {
 		}
 	}
 
-	// If for an http-api command the agent-target address is a URL, it must be handled differently
+	// If for an http-api command the agent-target address is a URL, it must be handled differently than dname and ip addresses
 	if len(target.Address["url"]) > 0 {
 		if target.Address["url"][0] != "" {
 			urlObject, err := parsePathBasedUrl(target.Address["url"][0])

--- a/utils/http/http.go
+++ b/utils/http/http.go
@@ -23,6 +23,10 @@ var (
 	log       *logger.Log
 )
 
+func init() {
+	log = logger.Logger(component, logger.Info, "", logger.Json)
+}
+
 type HttpOptions struct {
 	Target  *cacao.AgentTarget
 	Command *cacao.Command
@@ -52,7 +56,6 @@ func (httpRequest *HttpRequest) SkipCertificateValidation(skip bool) {
 }
 
 func (httpRequest *HttpRequest) Request(httpOptions HttpOptions) ([]byte, error) {
-	log = logger.Logger(component, logger.Info, "", logger.Json)
 	request, err := httpOptions.setupRequest()
 	if err != nil {
 		return []byte{}, err
@@ -201,9 +204,17 @@ func (httpOptions *HttpOptions) ExtractUrl() (string, error) {
 		}
 	}
 
+	// If for an http-api command the agent-target address is a URL, it must be handled differently
 	if len(target.Address["url"]) > 0 {
 		if target.Address["url"][0] != "" {
-			return parsePathBasedUrl(target.Address["url"][0])
+			urlObject, err := parsePathBasedUrl(target.Address["url"][0])
+			if err != nil {
+				return "", err
+			}
+			if (urlObject.Path != "" && urlObject.Path != "/") && urlObject.Path != path {
+				log.Warn("agent-target url has path that does not match http-api command path")
+			}
+			return urlObject.String(), nil
 		}
 	}
 	return buildSchemeAndHostname(path, target)
@@ -213,7 +224,7 @@ func buildSchemeAndHostname(path string, target *cacao.AgentTarget) (string, err
 	var hostname string
 
 	scheme := setDefaultScheme(target)
-	hostname, err := extractHostname(scheme, target)
+	hostname, err := extractHostname(target)
 	if err != nil {
 		return "", err
 	}
@@ -240,7 +251,7 @@ func setDefaultScheme(target *cacao.AgentTarget) string {
 	return scheme
 }
 
-func extractHostname(scheme string, target *cacao.AgentTarget) (string, error) {
+func extractHostname(target *cacao.AgentTarget) (string, error) {
 	var address string
 
 	if len(target.Address["dname"]) > 0 {
@@ -256,28 +267,22 @@ func extractHostname(scheme string, target *cacao.AgentTarget) (string, error) {
 			return "", errors.New("failed regex rule for domain name")
 		}
 		address = target.Address["ipv4"][0]
-	} else if len(target.Address["url"]) > 0 {
-		match, _ := regexp.MatchString(ipv4Regex, target.Address["url"][0])
-		if !match {
-			return "", errors.New("failed regex rule for domain name")
-		}
-		address = target.Address["url"][0]
+
 	} else {
 		return "", errors.New("unsupported target address type")
 	}
 	return address, nil
 }
 
-func parsePathBasedUrl(httpUrl string) (string, error) {
+func parsePathBasedUrl(httpUrl string) (*url.URL, error) {
 	parsedUrl, err := url.ParseRequestURI(httpUrl)
 	if err != nil {
-		return "", err
+		return parsedUrl, err
 	}
-
 	if parsedUrl.Hostname() == "" {
-		return "", errors.New("no domain name")
+		return parsedUrl, errors.New("no domain name")
 	}
-	return parsedUrl.String(), nil
+	return parsedUrl, nil
 }
 
 func validatePort(port string) error {


### PR DESCRIPTION
Supersedes #104 
Technically, one could specify a URL address for an agent/target, and then a path in the http-api command that "starts from" the agent-target URL address. This could still generate a valid command.

In this PR I thus simply added a warning that advises if the URL address has a path stemming from the domain name, and if that path is different from the path specified in the command.