### PR TITLE
Bugfix/74 send final ack after receiving result

### DIFF
--- a/internal/capability/controller/controller.go
+++ b/internal/capability/controller/controller.go
@@ -86,8 +86,10 @@ func (finController *FinController) Run() {
 
 // Handle goroutine call from mqtt stack
 func (finController *FinController) Handler(client mqtt.Client, msg mqtt.Message) {
+	// Might need to filter on fin topics in the future if communication is needed
 	if msg.Topic() != string("soarca") {
 		log.Trace("message was receive in wrong topic: " + msg.Topic())
+		return
 	}
 	payload := msg.Payload()
 	log.Trace(string(payload))

--- a/internal/fin/protocol/protocol.go
+++ b/internal/fin/protocol/protocol.go
@@ -166,7 +166,7 @@ func (protocol *FinProtocol) AwaitResultOrTimeout(command fin.Command) (map[stri
 						protocol.SendAck(finResult, command.CommandSubstructure.Authentication)
 						return finResult.ResultStructure.Variables, nil
 					} else {
-						protocol.SendAck(finResult, command.CommandSubstructure.Authentication)
+						protocol.SendNack(finResult, command.CommandSubstructure.Authentication)
 					}
 
 				} else {

--- a/internal/fin/protocol/protocol.go
+++ b/internal/fin/protocol/protocol.go
@@ -15,7 +15,7 @@ import (
 
 const defaultTimeout = 1
 const disconnectTimeout = 100
-const clientId = "soarca"
+const clientId = "soarca-fin-capability"
 const defaultQos = AtLeastOnce
 
 const (

--- a/test/unittest/finprotocol/finprotocol_test.go
+++ b/test/unittest/finprotocol/finprotocol_test.go
@@ -44,7 +44,7 @@ func TestTimeoutAndCallbackTimerElaspsed(t *testing.T) {
 	expectedCommand := model.NewCommand()
 	expectedCommand.CommandSubstructure.Context.Timeout = 1
 
-	result, err := prot.AwaitResultOrTimeout(expectedCommand)
+	result, err := prot.AwaitResultOrTimeout(expectedCommand, &mock_client)
 
 	assert.Equal(t, err, errors.New("no message received from fin while it was expected"))
 	assert.Equal(t, result, map[string]cacao.Variable{})
@@ -72,11 +72,13 @@ func TestTimeoutAndCallbackHandlerCalled(t *testing.T) {
 
 	fmt.Println("calling await")
 	go helper(&prot)
-	result, err := prot.AwaitResultOrTimeout(expectedCommand)
+	result, err := prot.AwaitResultOrTimeout(expectedCommand, &mock_client)
 	fmt.Println("done waiting")
 
 	assert.Equal(t, err, nil)
 	assert.Equal(t, result, map[string]cacao.Variable{"test": {Name: "test"}})
+	mock_client.AssertExpectations(t)
+	mock_token.AssertExpectations(t)
 	mock_token_ack.AssertExpectations(t)
 }
 


### PR DESCRIPTION
Fixes issue #74 

- Fixes an issue where fin capability could not receive messages due to colliding names.
- Sends final ack to fin when a results has been received
- Updated tests to also expect an ack to be send