### PR TITLE
fixed via add forgotten cache result parsing for GET /reporter/ call

### DIFF
--- a/models/api/reporter.go
+++ b/models/api/reporter.go
@@ -60,29 +60,11 @@ type StepExecutionReport struct {
 	// the execution ID for the invoked playbook
 }
 
-func CacheStatusEnum2String(status cache_model.Status) (string, error) {
-	switch status {
-	case cache_model.SuccessfullyExecuted:
-		return SuccessfullyExecuted, nil
-	case cache_model.Failed:
-		return Failed, nil
-	case cache_model.Ongoing:
-		return Ongoing, nil
-	case cache_model.ServerSideError:
-		return ServerSideError, nil
-	case cache_model.ClientSideError:
-		return ClientSideError, nil
-	case cache_model.TimeoutError:
-		return TimeoutError, nil
-	case cache_model.ExceptionConditionError:
-		return ExceptionConditionError, nil
-	case cache_model.AwaitUserInput:
-		return AwaitUserInput, nil
-	default:
-		return "", errors.New("unable to read execution information status")
-	}
+func CacheStatusEnum2String(status cache_model.Status) string {
+	return status.String()
 }
 
+// Level must be either "step" or "playbook"
 func GetCacheStatusText(status string, level string) (string, error) {
 	if level != ReportLevelPlaybook && level != ReportLevelStep {
 		return "", errors.New("invalid reporting level provided. use either 'playbook' or 'step'")

--- a/models/cache/cache.go
+++ b/models/cache/cache.go
@@ -20,6 +20,19 @@ const (
 	AwaitUserInput
 )
 
+func (status Status) String() string {
+	return [...]string{
+		"successfully_executed",
+		"failed",
+		"ongoing",
+		"server_side_error",
+		"client_side_error",
+		"timeout_error",
+		"exception_condition_error",
+		"await_user_input",
+	}[status]
+}
+
 type ExecutionEntry struct {
 	ExecutionId uuid.UUID
 	PlaybookId  string

--- a/routes/reporter/reporter_parser.go
+++ b/routes/reporter/reporter_parser.go
@@ -8,10 +8,7 @@ import (
 const defaultRequestInterval int = 5
 
 func parseCachePlaybookEntry(cacheEntry cache_model.ExecutionEntry) (api_model.PlaybookExecutionReport, error) {
-	playbookStatus, err := api_model.CacheStatusEnum2String(cacheEntry.Status)
-	if err != nil {
-		return api_model.PlaybookExecutionReport{}, err
-	}
+	playbookStatus := api_model.CacheStatusEnum2String(cacheEntry.Status)
 
 	playbookStatusText, err := api_model.GetCacheStatusText(playbookStatus, api_model.ReportLevelPlaybook)
 	if err != nil {
@@ -44,10 +41,8 @@ func parseCacheStepEntries(cacheStepEntries map[string]cache_model.StepResult) (
 	parsedEntries := map[string]api_model.StepExecutionReport{}
 	for stepId, stepEntry := range cacheStepEntries {
 
-		stepStatus, err := api_model.CacheStatusEnum2String(stepEntry.Status)
-		if err != nil {
-			return map[string]api_model.StepExecutionReport{}, err
-		}
+		stepStatus := api_model.CacheStatusEnum2String(stepEntry.Status)
+
 		stepStatusText, err := api_model.GetCacheStatusText(stepStatus, api_model.ReportLevelStep)
 		if err != nil {
 			return map[string]api_model.StepExecutionReport{}, err


### PR DESCRIPTION
@MaartendeKruijf how do we add schemes to the HTTP requests? It would have avoided this bug