### PR TITLE
feature/214 - fix reporting failed workflow due to failed step

### DIFF
--- a/internal/decomposer/decomposer.go
+++ b/internal/decomposer/decomposer.go
@@ -158,7 +158,7 @@ func (decomposer *Decomposer) ExecuteBranch(stepId string, scopeVariables cacao.
 		outputVariables, err := decomposer.ExecuteStep(currentStep, scopeVariables)
 
 		if err == nil {
-			stepId = currentStep.OnCompletion
+			stepId = onCompletionStepId
 			returnVariables.Merge(outputVariables)
 			scopeVariables.Merge(outputVariables)
 		} else {

--- a/internal/decomposer/decomposer.go
+++ b/internal/decomposer/decomposer.go
@@ -138,30 +138,31 @@ func (decomposer *Decomposer) ExecuteBranch(stepId string, scopeVariables cacao.
 			break
 		}
 
-		onSuccessStepId := currentStep.OnSuccess
-		if onSuccessStepId == "" {
-			onSuccessStepId = currentStep.OnCompletion
+		// Note: likely (but not certainly) on_success and on_faliure will be reworked
+		// to become workflow branching properties, with the addition of a success_condition
+		// boolean evaluation at step level.
+		// Effectively, we should thus only check for existance of on_completion, and
+		// report execution errors as such, not as playbook step failures - which will be handled
+		// with upcoming said on_success, on_failure, and success_condition properties
+		onCompletionStepId := currentStep.OnCompletion
+		if onCompletionStepId == "" {
+			onCompletionStepId = currentStep.OnSuccess
 		}
-		if _, ok := playbook.Workflow[onSuccessStepId]; !ok {
-			return cacao.NewVariables(), errors.New("empty success step")
+		if onCompletionStepId == "" {
+			onCompletionStepId = currentStep.OnFailure
 		}
-
-		onFailureStepId := currentStep.OnFailure
-		if onFailureStepId == "" {
-			onFailureStepId = currentStep.OnCompletion
-		}
-		if _, ok := playbook.Workflow[onFailureStepId]; !ok {
-			return cacao.NewVariables(), errors.New("empty failure step")
+		if _, ok := playbook.Workflow[onCompletionStepId]; !ok {
+			return cacao.NewVariables(), errors.New("empty completion step")
 		}
 
 		outputVariables, err := decomposer.ExecuteStep(currentStep, scopeVariables)
 
 		if err == nil {
-			stepId = onSuccessStepId
+			stepId = currentStep.OnCompletion
 			returnVariables.Merge(outputVariables)
 			scopeVariables.Merge(outputVariables)
 		} else {
-			stepId = onFailureStepId
+			return cacao.NewVariables(), fmt.Errorf("playbook execution failed at step [ %s ]. See step log for error information", stepId)
 		}
 	}
 

--- a/test/unittest/decomposer/decomposer_test.go
+++ b/test/unittest/decomposer/decomposer_test.go
@@ -501,7 +501,12 @@ func TestFailingStepResultsInFailingPlaybook(t *testing.T) {
 		Variables: cacao.NewVariables(expectedVariables),
 	}
 
-	mock_reporter.On("ReportWorkflowStart", executionId, playbook).Return()
+	layout := "2006-01-02T15:04:05.000Z"
+	str := "2014-11-12T11:45:26.371Z"
+	timeNow, _ := time.Parse(layout, str)
+	mock_time.On("Now").Return(timeNow)
+
+	mock_reporter.On("ReportWorkflowStart", executionId, playbook, timeNow).Return()
 	mock_time.On("Sleep", time.Millisecond*0).Return()
 	mock_action_executor.On("Execute", metaStep1, playbookStepMetadata1).Return(cacao.NewVariables(firstResult), nil)
 
@@ -524,8 +529,9 @@ func TestFailingStepResultsInFailingPlaybook(t *testing.T) {
 
 	mock_action_executor.On("Execute", metaStep3, playbookStepMetadata3).Return(cacao.NewVariables(), errors.New("everything broke"))
 
+	mock_time.On("Now").Return(timeNow)
 	expectedError := errors.New("playbook execution failed at step [ action--test3 ]. See step log for error information")
-	mock_reporter.On("ReportWorkflowEnd", executionId, playbook, expectedError).Return()
+	mock_reporter.On("ReportWorkflowEnd", executionId, playbook, expectedError, timeNow).Return()
 
 	_, err := decomposer.Execute(playbook)
 	t.Log(err)


### PR DESCRIPTION
To fix this, I changed the logic of assignment of the ID of the next step to execute.
The new logic is more in line with a consistent use of the CACAO V2 spec.