### PR TITLE
Bugfix/223 loading playbooks from database is missing authentication information

### DIFF
--- a/database/playbook/playbook.go
+++ b/database/playbook/playbook.go
@@ -8,6 +8,7 @@ import (
 	validator "soarca/internal/validators"
 	"soarca/models/api"
 	"soarca/models/cacao"
+	"soarca/models/decoder"
 )
 
 type IPlaybookRepository interface {
@@ -63,6 +64,7 @@ func (playbookRepo *PlaybookRepository) GetPlaybooks() ([]cacao.Playbook, error)
 	for _, playbook := range playbooks {
 		// get the cacao playbook id and add to the return list
 		playbook, ok := playbook.(cacao.Playbook)
+		decoder.SetPlaybookKeysAsId(&playbook)
 		if !ok {
 			return nil, errors.New("type assertion failed for cacao.playbook type")
 		}
@@ -78,6 +80,7 @@ func (playbookRepo *PlaybookRepository) Create(jsonData *[]byte) (cacao.Playbook
 		return cacao.Playbook{}, err
 	}
 	playbook, ok := client_data.(cacao.Playbook)
+	decoder.SetPlaybookKeysAsId(&playbook)
 	if !ok {
 		// handle incorrect casting
 		return cacao.Playbook{}, errors.New("failed to cast playbook object")
@@ -93,8 +96,9 @@ func (playbookRepo *PlaybookRepository) Read(id string) (cacao.Playbook, error) 
 	}
 
 	cacaoPlaybook, ok := returnedObject.(cacao.Playbook)
+	decoder.SetPlaybookKeysAsId(&cacaoPlaybook)
 	if !ok {
-		err = errors.New("Could not cast lookup object to cacao.Playbook type")
+		err = errors.New("could not cast lookup object to cacao.Playbook type")
 		return cacao.Playbook{}, err
 	}
 
@@ -108,8 +112,9 @@ func (playbookRepo *PlaybookRepository) Update(id string, jsonData *[]byte) (cac
 		return cacao.Playbook{}, err
 	}
 	cacaoPlaybook, ok := client_data.(cacao.Playbook)
+	decoder.SetPlaybookKeysAsId(&cacaoPlaybook)
 	if !ok {
-		err = errors.New("Could not cast lookup object to cacao.Playbook type")
+		err = errors.New("could not cast lookup object to cacao.Playbook type")
 		return cacao.Playbook{}, err
 	}
 	return cacaoPlaybook, playbookRepo.db.Update(id, client_data)

--- a/models/decoder/cacao.go
+++ b/models/decoder/cacao.go
@@ -41,9 +41,9 @@ func DecodeValidate(data []byte) *cacao.Playbook {
 }
 
 func SetPlaybookKeysAsId(playbook *cacao.Playbook) {
-	for key, workflow := range playbook.Workflow {
-		workflow.ID = key
-		playbook.Workflow[key] = workflow
+	for key, step := range playbook.Workflow {
+		step.ID = key
+		playbook.Workflow[key] = step
 	}
 
 	for key, target := range playbook.TargetDefinitions {

--- a/models/decoder/cacao.go
+++ b/models/decoder/cacao.go
@@ -40,14 +40,7 @@ func DecodeValidate(data []byte) *cacao.Playbook {
 	return playbook
 }
 
-func decode(data []byte) *cacao.Playbook {
-	playbook := cacao.NewPlaybook()
-
-	if err := json.Unmarshal(data, playbook); err != nil {
-		log.Error(err)
-		return nil
-	}
-
+func SetPlaybookKeysAsId(playbook *cacao.Playbook) {
 	for key, workflow := range playbook.Workflow {
 		workflow.ID = key
 		playbook.Workflow[key] = workflow
@@ -79,6 +72,17 @@ func decode(data []byte) *cacao.Playbook {
 			step.StepVariables.InsertOrReplace(variable)
 		}
 	}
+}
+
+func decode(data []byte) *cacao.Playbook {
+	playbook := cacao.NewPlaybook()
+
+	if err := json.Unmarshal(data, playbook); err != nil {
+		log.Error(err)
+		return nil
+	}
+
+	SetPlaybookKeysAsId(playbook)
 
 	return playbook
 }


### PR DESCRIPTION
This is more of a patch to the playbook loading from database as the decode is not used but ID are patched individually