### PR TITLE
Change reporting calls timings to ensure consistency

### DIFF
--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -95,12 +95,12 @@ func (controller *Controller) NewDecomposer() decomposer.IDecomposer {
 		log.Error("could not load main Cache as reporter for decomposer and executors")
 	}
 
-	actionExecutor := action.New(capabilities, reporter)
-	playbookActionExecutor := playbook_action.New(controller, controller, reporter)
-	stixComparison := comparison.New()
-	conditionExecutor := condition.New(stixComparison, reporter)
-	guid := new(guid.Guid)
 	soarcaTime := new(timeUtil.Time)
+	actionExecutor := action.New(capabilities, reporter, soarcaTime)
+	playbookActionExecutor := playbook_action.New(controller, controller, reporter, soarcaTime)
+	stixComparison := comparison.New()
+	conditionExecutor := condition.New(stixComparison, reporter, soarcaTime)
+	guid := new(guid.Guid)
 	decompose := decomposer.New(actionExecutor,
 		playbookActionExecutor,
 		conditionExecutor,

--- a/internal/decomposer/decomposer.go
+++ b/internal/decomposer/decomposer.go
@@ -13,7 +13,7 @@ import (
 	"soarca/logger"
 	"soarca/models/cacao"
 	"soarca/models/execution"
-	"soarca/utils/time"
+	timeUtil "soarca/utils/time"
 
 	t "time"
 
@@ -47,7 +47,7 @@ func New(actionExecutor action.IExecuter,
 	condition condition.IExecuter,
 	guid guid.IGuid,
 	reporter reporter.IWorkflowReporter,
-	time time.ITime) *Decomposer {
+	time timeUtil.ITime) *Decomposer {
 
 	return &Decomposer{actionExecutor: actionExecutor,
 		playbookActionExecutor: playbookActionExecutor,
@@ -66,7 +66,7 @@ type Decomposer struct {
 	conditionExecutor      condition.IExecuter
 	guid                   guid.IGuid
 	reporter               reporter.IWorkflowReporter
-	time                   time.ITime
+	time                   timeUtil.ITime
 }
 
 // Execute a Playbook
@@ -106,13 +106,13 @@ func (decomposer *Decomposer) execute(playbook cacao.Playbook) error {
 	variables.Merge(playbook.PlaybookVariables)
 
 	// Reporting workflow instantiation
-	decomposer.reporter.ReportWorkflowStart(decomposer.details.ExecutionId, playbook)
+	decomposer.reporter.ReportWorkflowStart(decomposer.details.ExecutionId, playbook, decomposer.time.Now())
 
 	outputVariables, err := decomposer.ExecuteBranch(stepId, variables)
 
 	decomposer.details.Variables = outputVariables
 	// Reporting workflow end
-	decomposer.reporter.ReportWorkflowEnd(decomposer.details.ExecutionId, playbook, err)
+	decomposer.reporter.ReportWorkflowEnd(decomposer.details.ExecutionId, playbook, err, decomposer.time.Now())
 
 	return err
 }

--- a/internal/executors/action/action.go
+++ b/internal/executors/action/action.go
@@ -50,21 +50,18 @@ func (executor *Executor) Execute(meta execution.Metadata, metadata PlaybookStep
 
 	executor.reporter.ReportStepStart(meta.ExecutionId, metadata.Step, metadata.Variables, executor.time.Now())
 
-	var reportVars cacao.Variables
-	var reportErr error
+	returnVariables := cacao.NewVariables()
+	var err error
 	defer func() {
-		executor.reporter.ReportStepEnd(meta.ExecutionId, metadata.Step, reportVars, reportErr, executor.time.Now())
+		executor.reporter.ReportStepEnd(meta.ExecutionId, metadata.Step, returnVariables, err, executor.time.Now())
 	}()
 
 	if metadata.Step.Type != cacao.StepTypeAction {
-		err := errors.New("the provided step type is not compatible with this executor")
+		err = errors.New("the provided step type is not compatible with this executor")
 		log.Error(err)
-		reportVars = cacao.NewVariables()
-		reportErr = err
-		// executor.reporter.ReportStepEnd(meta.ExecutionId, metadata.Step, cacao.NewVariables(), err, executor.time.Now())
 		return cacao.NewVariables(), err
 	}
-	returnVariables := cacao.NewVariables()
+
 	for _, command := range metadata.Step.Commands {
 		// NOTE: This assumes we want to run Command for every Target individually.
 		//       Is that something we want to enforce or leave up to the capability?
@@ -90,9 +87,6 @@ func (executor *Executor) Execute(meta execution.Metadata, metadata PlaybookStep
 
 			if err != nil {
 				log.Error("Error executing Command ", err)
-				// executor.reporter.ReportStepEnd(meta.ExecutionId, metadata.Step, returnVariables, err, executor.time.Now())
-				reportErr = err
-				reportVars = returnVariables
 				return cacao.NewVariables(), err
 			} else {
 				log.Debug("Command executed")
@@ -100,9 +94,6 @@ func (executor *Executor) Execute(meta execution.Metadata, metadata PlaybookStep
 		}
 	}
 
-	// executor.reporter.ReportStepEnd(meta.ExecutionId, metadata.Step, returnVariables, nil, executor.time.Now())
-	reportVars = returnVariables
-	reportErr = nil
 	return returnVariables, nil
 }
 

--- a/internal/executors/action/action.go
+++ b/internal/executors/action/action.go
@@ -9,6 +9,7 @@ import (
 	"soarca/logger"
 	"soarca/models/cacao"
 	"soarca/models/execution"
+	timeUtil "soarca/utils/time"
 )
 
 var component = reflect.TypeOf(Executor{}).PkgPath()
@@ -18,10 +19,11 @@ func init() {
 	log = logger.Logger(component, logger.Info, "", logger.Json)
 }
 
-func New(capabilities map[string]capability.ICapability, reporter reporter.IStepReporter) *Executor {
+func New(capabilities map[string]capability.ICapability, reporter reporter.IStepReporter, time timeUtil.ITime) *Executor {
 	var instance = Executor{}
 	instance.capabilities = capabilities
 	instance.reporter = reporter
+	instance.time = time
 	return &instance
 }
 
@@ -41,16 +43,17 @@ type IExecuter interface {
 type Executor struct {
 	capabilities map[string]capability.ICapability
 	reporter     reporter.IStepReporter
+	time         timeUtil.ITime
 }
 
 func (executor *Executor) Execute(meta execution.Metadata, metadata PlaybookStepMetadata) (cacao.Variables, error) {
 
-	executor.reporter.ReportStepStart(meta.ExecutionId, metadata.Step, metadata.Variables)
+	executor.reporter.ReportStepStart(meta.ExecutionId, metadata.Step, metadata.Variables, executor.time.Now())
 
 	if metadata.Step.Type != cacao.StepTypeAction {
 		err := errors.New("the provided step type is not compatible with this executor")
 		log.Error(err)
-		executor.reporter.ReportStepEnd(meta.ExecutionId, metadata.Step, cacao.NewVariables(), err)
+		executor.reporter.ReportStepEnd(meta.ExecutionId, metadata.Step, cacao.NewVariables(), err, executor.time.Now())
 		return cacao.NewVariables(), err
 	}
 	returnVariables := cacao.NewVariables()
@@ -79,14 +82,14 @@ func (executor *Executor) Execute(meta execution.Metadata, metadata PlaybookStep
 
 			if err != nil {
 				log.Error("Error executing Command ", err)
-				executor.reporter.ReportStepEnd(meta.ExecutionId, metadata.Step, returnVariables, err)
+				executor.reporter.ReportStepEnd(meta.ExecutionId, metadata.Step, returnVariables, err, executor.time.Now())
 				return cacao.NewVariables(), err
 			} else {
 				log.Debug("Command executed")
 			}
 		}
 	}
-	executor.reporter.ReportStepEnd(meta.ExecutionId, metadata.Step, returnVariables, nil)
+	executor.reporter.ReportStepEnd(meta.ExecutionId, metadata.Step, returnVariables, nil, executor.time.Now())
 	return returnVariables, nil
 }
 

--- a/internal/executors/condition/condition.go
+++ b/internal/executors/condition/condition.go
@@ -9,6 +9,7 @@ import (
 	"soarca/models/cacao"
 	"soarca/models/execution"
 	"soarca/utils/stix/expression/comparison"
+	timeUtil "soarca/utils/time"
 )
 
 var component = reflect.TypeOf(Executor{}).PkgPath()
@@ -19,9 +20,9 @@ func init() {
 }
 
 func New(comparison comparison.IComparison,
-	reporter reporter.IStepReporter) *Executor {
+	reporter reporter.IStepReporter, time timeUtil.ITime) *Executor {
 	return &Executor{comparison: comparison,
-		reporter: reporter}
+		reporter: reporter, time: time}
 }
 
 type IExecuter interface {
@@ -32,6 +33,7 @@ type IExecuter interface {
 type Executor struct {
 	comparison comparison.IComparison
 	reporter   reporter.IStepReporter
+	time       timeUtil.ITime
 }
 
 func (executor *Executor) Execute(meta execution.Metadata, step cacao.Step, variables cacao.Variables) (string, bool, error) {
@@ -42,7 +44,7 @@ func (executor *Executor) Execute(meta execution.Metadata, step cacao.Step, vari
 		return step.OnFailure, false, err
 	}
 
-	executor.reporter.ReportStepStart(meta.ExecutionId, step, variables)
+	executor.reporter.ReportStepStart(meta.ExecutionId, step, variables, executor.time.Now())
 
 	result, err := executor.comparison.Evaluate(step.Condition, variables)
 
@@ -50,7 +52,8 @@ func (executor *Executor) Execute(meta execution.Metadata, step cacao.Step, vari
 	executor.reporter.ReportStepEnd(meta.ExecutionId,
 		step,
 		variables,
-		err)
+		err,
+		executor.time.Now())
 
 	if err != nil {
 		log.Error(err)

--- a/internal/executors/condition/condition.go
+++ b/internal/executors/condition/condition.go
@@ -46,22 +46,14 @@ func (executor *Executor) Execute(meta execution.Metadata, step cacao.Step, vari
 
 	executor.reporter.ReportStepStart(meta.ExecutionId, step, variables, executor.time.Now())
 
-	var reportErr error
+	var err error
 	defer func() {
-		executor.reporter.ReportStepEnd(meta.ExecutionId, step, variables, reportErr, executor.time.Now())
+		executor.reporter.ReportStepEnd(meta.ExecutionId, step, variables, err, executor.time.Now())
 	}()
 
 	result, err := executor.comparison.Evaluate(step.Condition, variables)
-
-	// executor.reporter.ReportStepEnd(meta.ExecutionId,
-	// 	step,
-	// 	variables,
-	// 	err,
-	// 	executor.time.Now())
-
 	if err != nil {
 		log.Error(err)
-		reportErr = err
 		return "", false, err
 	}
 

--- a/internal/executors/condition/condition.go
+++ b/internal/executors/condition/condition.go
@@ -46,17 +46,22 @@ func (executor *Executor) Execute(meta execution.Metadata, step cacao.Step, vari
 
 	executor.reporter.ReportStepStart(meta.ExecutionId, step, variables, executor.time.Now())
 
+	var reportErr error
+	defer func() {
+		executor.reporter.ReportStepEnd(meta.ExecutionId, step, variables, reportErr, executor.time.Now())
+	}()
+
 	result, err := executor.comparison.Evaluate(step.Condition, variables)
 
-	// We are reporting early to not have double reporting
-	executor.reporter.ReportStepEnd(meta.ExecutionId,
-		step,
-		variables,
-		err,
-		executor.time.Now())
+	// executor.reporter.ReportStepEnd(meta.ExecutionId,
+	// 	step,
+	// 	variables,
+	// 	err,
+	// 	executor.time.Now())
 
 	if err != nil {
 		log.Error(err)
+		reportErr = err
 		return "", false, err
 	}
 

--- a/internal/executors/playbook_action/playbook_action.go
+++ b/internal/executors/playbook_action/playbook_action.go
@@ -61,10 +61,10 @@ func (playbookAction *PlaybookAction) Execute(metadata execution.Metadata,
 	if err != nil {
 		err = errors.New(fmt.Sprint("execution of playbook failed with error: ", err))
 		log.Error(err)
-		playbookAction.reporter.ReportStepEnd(metadata.ExecutionId, step, playbook.PlaybookVariables, err, playbookAction.time.Now())
+		playbookAction.reporter.ReportStepEnd(metadata.ExecutionId, step, details.Variables, err, playbookAction.time.Now())
 		return cacao.NewVariables(), err
 	}
-	playbookAction.reporter.ReportStepEnd(metadata.ExecutionId, step, playbook.PlaybookVariables, nil, playbookAction.time.Now())
+	playbookAction.reporter.ReportStepEnd(metadata.ExecutionId, step, details.Variables, nil, playbookAction.time.Now())
 	return details.Variables, nil
 
 }

--- a/internal/executors/playbook_action/playbook_action.go
+++ b/internal/executors/playbook_action/playbook_action.go
@@ -39,10 +39,16 @@ func (playbookAction *PlaybookAction) Execute(metadata execution.Metadata,
 
 	playbookAction.reporter.ReportStepStart(metadata.ExecutionId, step, variables, playbookAction.time.Now())
 
+	var reportVars cacao.Variables
+	var reportErr error
+	defer func() {
+		playbookAction.reporter.ReportStepEnd(metadata.ExecutionId, step, reportVars, reportErr, playbookAction.time.Now())
+	}()
+
 	if step.Type != cacao.StepTypePlaybookAction {
 		err := errors.New(fmt.Sprint("step type is not of type ", cacao.StepTypePlaybookAction))
 		log.Error(err)
-		playbookAction.reporter.ReportStepEnd(metadata.ExecutionId, step, cacao.NewVariables(), nil, playbookAction.time.Now())
+		// playbookAction.reporter.ReportStepEnd(metadata.ExecutionId, step, cacao.NewVariables(), nil, playbookAction.time.Now())
 		return cacao.NewVariables(), err
 	}
 
@@ -61,10 +67,14 @@ func (playbookAction *PlaybookAction) Execute(metadata execution.Metadata,
 	if err != nil {
 		err = errors.New(fmt.Sprint("execution of playbook failed with error: ", err))
 		log.Error(err)
-		playbookAction.reporter.ReportStepEnd(metadata.ExecutionId, step, details.Variables, err, playbookAction.time.Now())
+		//playbookAction.reporter.ReportStepEnd(metadata.ExecutionId, step, details.Variables, err, playbookAction.time.Now())
+		reportVars = details.Variables
+		reportErr = err
 		return cacao.NewVariables(), err
 	}
-	playbookAction.reporter.ReportStepEnd(metadata.ExecutionId, step, details.Variables, nil, playbookAction.time.Now())
+	//playbookAction.reporter.ReportStepEnd(metadata.ExecutionId, step, details.Variables, nil, playbookAction.time.Now())
+	reportVars = details.Variables
+	reportErr = nil
 	return details.Variables, nil
 
 }

--- a/internal/executors/playbook_action/playbook_action.go
+++ b/internal/executors/playbook_action/playbook_action.go
@@ -10,12 +10,14 @@ import (
 	"soarca/logger"
 	"soarca/models/cacao"
 	"soarca/models/execution"
+	timeUtil "soarca/utils/time"
 )
 
 type PlaybookAction struct {
 	decomposerController decomposer_controller.IController
 	databaseController   database.IController
 	reporter             reporter.IStepReporter
+	time                 timeUtil.ITime
 }
 
 var component = reflect.TypeOf(PlaybookAction{}).PkgPath()
@@ -26,8 +28,8 @@ func init() {
 }
 
 func New(controller decomposer_controller.IController,
-	database database.IController, reporter reporter.IStepReporter) *PlaybookAction {
-	return &PlaybookAction{decomposerController: controller, databaseController: database, reporter: reporter}
+	database database.IController, reporter reporter.IStepReporter, time timeUtil.ITime) *PlaybookAction {
+	return &PlaybookAction{decomposerController: controller, databaseController: database, reporter: reporter, time: time}
 }
 
 func (playbookAction *PlaybookAction) Execute(metadata execution.Metadata,
@@ -35,12 +37,12 @@ func (playbookAction *PlaybookAction) Execute(metadata execution.Metadata,
 	variables cacao.Variables) (cacao.Variables, error) {
 	log.Trace(metadata.ExecutionId)
 
-	playbookAction.reporter.ReportStepStart(metadata.ExecutionId, step, variables)
+	playbookAction.reporter.ReportStepStart(metadata.ExecutionId, step, variables, playbookAction.time.Now())
 
 	if step.Type != cacao.StepTypePlaybookAction {
 		err := errors.New(fmt.Sprint("step type is not of type ", cacao.StepTypePlaybookAction))
 		log.Error(err)
-		playbookAction.reporter.ReportStepEnd(metadata.ExecutionId, step, cacao.NewVariables(), nil)
+		playbookAction.reporter.ReportStepEnd(metadata.ExecutionId, step, cacao.NewVariables(), nil, playbookAction.time.Now())
 		return cacao.NewVariables(), err
 	}
 
@@ -59,10 +61,10 @@ func (playbookAction *PlaybookAction) Execute(metadata execution.Metadata,
 	if err != nil {
 		err = errors.New(fmt.Sprint("execution of playbook failed with error: ", err))
 		log.Error(err)
-		playbookAction.reporter.ReportStepEnd(metadata.ExecutionId, step, playbook.PlaybookVariables, err)
+		playbookAction.reporter.ReportStepEnd(metadata.ExecutionId, step, playbook.PlaybookVariables, err, playbookAction.time.Now())
 		return cacao.NewVariables(), err
 	}
-	playbookAction.reporter.ReportStepEnd(metadata.ExecutionId, step, playbook.PlaybookVariables, nil)
+	playbookAction.reporter.ReportStepEnd(metadata.ExecutionId, step, playbook.PlaybookVariables, nil, playbookAction.time.Now())
 	return details.Variables, nil
 
 }

--- a/internal/executors/playbook_action/playbook_action.go
+++ b/internal/executors/playbook_action/playbook_action.go
@@ -39,16 +39,15 @@ func (playbookAction *PlaybookAction) Execute(metadata execution.Metadata,
 
 	playbookAction.reporter.ReportStepStart(metadata.ExecutionId, step, variables, playbookAction.time.Now())
 
-	var reportVars cacao.Variables
-	var reportErr error
+	var reportVars = cacao.NewVariables()
+	var err error
 	defer func() {
-		playbookAction.reporter.ReportStepEnd(metadata.ExecutionId, step, reportVars, reportErr, playbookAction.time.Now())
+		playbookAction.reporter.ReportStepEnd(metadata.ExecutionId, step, reportVars, err, playbookAction.time.Now())
 	}()
 
 	if step.Type != cacao.StepTypePlaybookAction {
 		err := errors.New(fmt.Sprint("step type is not of type ", cacao.StepTypePlaybookAction))
 		log.Error(err)
-		// playbookAction.reporter.ReportStepEnd(metadata.ExecutionId, step, cacao.NewVariables(), nil, playbookAction.time.Now())
 		return cacao.NewVariables(), err
 	}
 
@@ -67,14 +66,10 @@ func (playbookAction *PlaybookAction) Execute(metadata execution.Metadata,
 	if err != nil {
 		err = errors.New(fmt.Sprint("execution of playbook failed with error: ", err))
 		log.Error(err)
-		//playbookAction.reporter.ReportStepEnd(metadata.ExecutionId, step, details.Variables, err, playbookAction.time.Now())
-		reportVars = details.Variables
-		reportErr = err
+		reportVars = details.Variables // make sure vars are reported
 		return cacao.NewVariables(), err
 	}
-	//playbookAction.reporter.ReportStepEnd(metadata.ExecutionId, step, details.Variables, nil, playbookAction.time.Now())
-	reportVars = details.Variables
-	reportErr = nil
+	reportVars = details.Variables // make sure vars are reported
 	return details.Variables, nil
 
 }

--- a/internal/reporter/downstream_reporter/downstream_reporter.go
+++ b/internal/reporter/downstream_reporter/downstream_reporter.go
@@ -2,14 +2,15 @@ package downstream_reporter
 
 import (
 	"soarca/models/cacao"
+	"time"
 
 	"github.com/google/uuid"
 )
 
 type IDownStreamReporter interface {
-	ReportWorkflowStart(executionId uuid.UUID, playbook cacao.Playbook) error
-	ReportWorkflowEnd(executionId uuid.UUID, playbook cacao.Playbook, err error) error
+	ReportWorkflowStart(executionId uuid.UUID, playbook cacao.Playbook, at time.Time) error
+	ReportWorkflowEnd(executionId uuid.UUID, playbook cacao.Playbook, err error, at time.Time) error
 
-	ReportStepStart(executionId uuid.UUID, step cacao.Step, stepResults cacao.Variables) error
-	ReportStepEnd(executionId uuid.UUID, step cacao.Step, stepResults cacao.Variables, err error) error
+	ReportStepStart(executionId uuid.UUID, step cacao.Step, stepResults cacao.Variables, at time.Time) error
+	ReportStepEnd(executionId uuid.UUID, step cacao.Step, stepResults cacao.Variables, err error, at time.Time) error
 }

--- a/internal/reporter/reporter.go
+++ b/internal/reporter/reporter.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"reflect"
 	"strconv"
-	"sync"
 
 	downstreamReporter "soarca/internal/reporter/downstream_reporter"
 	"soarca/logger"
@@ -38,11 +37,20 @@ type IStepReporter interface {
 
 const MaxReporters int = 10
 
+// TODO:
+// - DONE remove sync wait group mechanisms
+// - add reported_started_on, reported_ended_on
+// - change reporting interface to pass in-code start and end time, to be
+//		collected before reporting function invocation
+// - remove constraint of updating step only if workflow still ongoing
+// - perhaps still add constrain of reporting rimeout.
+// - update documentation
+// - update tests
+
 // High-level reporter class with injection of specific reporters
 type Reporter struct {
-	reporters          []downstreamReporter.IDownStreamReporter
-	maxReporters       int
-	reportingWaitGroup sync.WaitGroup
+	reporters    []downstreamReporter.IDownStreamReporter
+	maxReporters int
 }
 
 func New(reporters []downstreamReporter.IDownStreamReporter) *Reporter {
@@ -66,7 +74,6 @@ func (reporter *Reporter) RegisterReporters(reporters []downstreamReporter.IDown
 // ######################## IWorkflowReporter interface
 
 func (reporter *Reporter) reportWorkflowStart(executionId uuid.UUID, playbook cacao.Playbook) {
-	defer reporter.reportingWaitGroup.Done()
 	for _, rep := range reporter.reporters {
 		err := rep.ReportWorkflowStart(executionId, playbook)
 		if err != nil {
@@ -75,13 +82,11 @@ func (reporter *Reporter) reportWorkflowStart(executionId uuid.UUID, playbook ca
 	}
 }
 func (reporter *Reporter) ReportWorkflowStart(executionId uuid.UUID, playbook cacao.Playbook) {
-	reporter.reportingWaitGroup.Add(1)
 	log.Trace(fmt.Sprintf("[execution: %s, playbook: %s] reporting workflow start", executionId, playbook.ID))
 	go reporter.reportWorkflowStart(executionId, playbook)
 }
 
 func (reporter *Reporter) reportWorkflowEnd(executionId uuid.UUID, playbook cacao.Playbook, workflowError error) {
-	defer reporter.reportingWaitGroup.Done()
 	for _, rep := range reporter.reporters {
 		err := rep.ReportWorkflowEnd(executionId, playbook, workflowError)
 		if err != nil {
@@ -90,8 +95,6 @@ func (reporter *Reporter) reportWorkflowEnd(executionId uuid.UUID, playbook caca
 	}
 }
 func (reporter *Reporter) ReportWorkflowEnd(executionId uuid.UUID, playbook cacao.Playbook, workflowError error) {
-	reporter.reportingWaitGroup.Wait()
-	reporter.reportingWaitGroup.Add(1)
 	log.Trace(fmt.Sprintf("[execution: %s, playbook: %s] reporting workflow end", executionId, playbook.ID))
 	go reporter.reportWorkflowEnd(executionId, playbook, workflowError)
 }
@@ -99,7 +102,6 @@ func (reporter *Reporter) ReportWorkflowEnd(executionId uuid.UUID, playbook caca
 // ######################## IStepReporter interface
 
 func (reporter *Reporter) reporStepStart(executionId uuid.UUID, step cacao.Step, returnVars cacao.Variables) {
-	defer reporter.reportingWaitGroup.Done()
 	for _, rep := range reporter.reporters {
 		err := rep.ReportStepStart(executionId, step, returnVars)
 		if err != nil {
@@ -108,13 +110,11 @@ func (reporter *Reporter) reporStepStart(executionId uuid.UUID, step cacao.Step,
 	}
 }
 func (reporter *Reporter) ReportStepStart(executionId uuid.UUID, step cacao.Step, returnVars cacao.Variables) {
-	reporter.reportingWaitGroup.Add(1)
 	log.Trace(fmt.Sprintf("[execution: %s, step: %s] reporting step start", executionId, step.ID))
 	go reporter.reporStepStart(executionId, step, returnVars)
 }
 
 func (reporter *Reporter) reportStepEnd(executionId uuid.UUID, step cacao.Step, returnVars cacao.Variables, stepError error) {
-	defer reporter.reportingWaitGroup.Done()
 	for _, rep := range reporter.reporters {
 		err := rep.ReportStepEnd(executionId, step, returnVars, stepError)
 		if err != nil {
@@ -123,7 +123,6 @@ func (reporter *Reporter) reportStepEnd(executionId uuid.UUID, step cacao.Step, 
 	}
 }
 func (reporter *Reporter) ReportStepEnd(executionId uuid.UUID, step cacao.Step, returnVars cacao.Variables, stepError error) {
-	reporter.reportingWaitGroup.Add(1)
 	log.Trace(fmt.Sprintf("[execution: %s, step: %s] reporting step end", executionId, step.ID))
 	go reporter.reportStepEnd(executionId, step, returnVars, stepError)
 }

--- a/internal/reporter/reporter.go
+++ b/internal/reporter/reporter.go
@@ -38,12 +38,6 @@ type IStepReporter interface {
 
 const MaxReporters int = 10
 
-// TODO:
-// - DONE remove sync wait group mechanisms
-// - DONE change reporting interface to pass in-code start and end time
-// - DONE remove constraint of updating step only if workflow still ongoing
-// - update tests
-
 // High-level reporter class with injection of specific reporters
 type Reporter struct {
 	reporters    []downstreamReporter.IDownStreamReporter

--- a/internal/reporter/reporter.go
+++ b/internal/reporter/reporter.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"reflect"
 	"strconv"
+	"sync"
 
 	downstreamReporter "soarca/internal/reporter/downstream_reporter"
 	"soarca/logger"
@@ -39,8 +40,9 @@ const MaxReporters int = 10
 
 // High-level reporter class with injection of specific reporters
 type Reporter struct {
-	reporters    []downstreamReporter.IDownStreamReporter
-	maxReporters int
+	reporters          []downstreamReporter.IDownStreamReporter
+	maxReporters       int
+	reportingWaitGroup sync.WaitGroup
 }
 
 func New(reporters []downstreamReporter.IDownStreamReporter) *Reporter {
@@ -64,6 +66,7 @@ func (reporter *Reporter) RegisterReporters(reporters []downstreamReporter.IDown
 // ######################## IWorkflowReporter interface
 
 func (reporter *Reporter) reportWorkflowStart(executionId uuid.UUID, playbook cacao.Playbook) {
+	defer reporter.reportingWaitGroup.Done()
 	for _, rep := range reporter.reporters {
 		err := rep.ReportWorkflowStart(executionId, playbook)
 		if err != nil {
@@ -72,11 +75,13 @@ func (reporter *Reporter) reportWorkflowStart(executionId uuid.UUID, playbook ca
 	}
 }
 func (reporter *Reporter) ReportWorkflowStart(executionId uuid.UUID, playbook cacao.Playbook) {
+	reporter.reportingWaitGroup.Add(1)
 	log.Trace(fmt.Sprintf("[execution: %s, playbook: %s] reporting workflow start", executionId, playbook.ID))
 	go reporter.reportWorkflowStart(executionId, playbook)
 }
 
 func (reporter *Reporter) reportWorkflowEnd(executionId uuid.UUID, playbook cacao.Playbook, workflowError error) {
+	defer reporter.reportingWaitGroup.Done()
 	for _, rep := range reporter.reporters {
 		err := rep.ReportWorkflowEnd(executionId, playbook, workflowError)
 		if err != nil {
@@ -85,6 +90,8 @@ func (reporter *Reporter) reportWorkflowEnd(executionId uuid.UUID, playbook caca
 	}
 }
 func (reporter *Reporter) ReportWorkflowEnd(executionId uuid.UUID, playbook cacao.Playbook, workflowError error) {
+	reporter.reportingWaitGroup.Wait()
+	reporter.reportingWaitGroup.Add(1)
 	log.Trace(fmt.Sprintf("[execution: %s, playbook: %s] reporting workflow end", executionId, playbook.ID))
 	go reporter.reportWorkflowEnd(executionId, playbook, workflowError)
 }
@@ -92,6 +99,7 @@ func (reporter *Reporter) ReportWorkflowEnd(executionId uuid.UUID, playbook caca
 // ######################## IStepReporter interface
 
 func (reporter *Reporter) reporStepStart(executionId uuid.UUID, step cacao.Step, returnVars cacao.Variables) {
+	defer reporter.reportingWaitGroup.Done()
 	for _, rep := range reporter.reporters {
 		err := rep.ReportStepStart(executionId, step, returnVars)
 		if err != nil {
@@ -100,11 +108,13 @@ func (reporter *Reporter) reporStepStart(executionId uuid.UUID, step cacao.Step,
 	}
 }
 func (reporter *Reporter) ReportStepStart(executionId uuid.UUID, step cacao.Step, returnVars cacao.Variables) {
+	reporter.reportingWaitGroup.Add(1)
 	log.Trace(fmt.Sprintf("[execution: %s, step: %s] reporting step start", executionId, step.ID))
 	go reporter.reporStepStart(executionId, step, returnVars)
 }
 
 func (reporter *Reporter) reportStepEnd(executionId uuid.UUID, step cacao.Step, returnVars cacao.Variables, stepError error) {
+	defer reporter.reportingWaitGroup.Done()
 	for _, rep := range reporter.reporters {
 		err := rep.ReportStepEnd(executionId, step, returnVars, stepError)
 		if err != nil {
@@ -113,6 +123,7 @@ func (reporter *Reporter) reportStepEnd(executionId uuid.UUID, step cacao.Step, 
 	}
 }
 func (reporter *Reporter) ReportStepEnd(executionId uuid.UUID, step cacao.Step, returnVars cacao.Variables, stepError error) {
+	reporter.reportingWaitGroup.Add(1)
 	log.Trace(fmt.Sprintf("[execution: %s, step: %s] reporting step end", executionId, step.ID))
 	go reporter.reportStepEnd(executionId, step, returnVars, stepError)
 }

--- a/internal/reporter/reporter.go
+++ b/internal/reporter/reporter.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"reflect"
 	"strconv"
+	"time"
 
 	downstreamReporter "soarca/internal/reporter/downstream_reporter"
 	"soarca/logger"
@@ -26,25 +27,21 @@ func init() {
 // Reporter interfaces
 type IWorkflowReporter interface {
 	// -> Give info to downstream reporters
-	ReportWorkflowStart(executionId uuid.UUID, playbook cacao.Playbook)
-	ReportWorkflowEnd(executionId uuid.UUID, playbook cacao.Playbook, workflowError error)
+	ReportWorkflowStart(executionId uuid.UUID, playbook cacao.Playbook, at time.Time)
+	ReportWorkflowEnd(executionId uuid.UUID, playbook cacao.Playbook, workflowError error, at time.Time)
 }
 type IStepReporter interface {
 	// -> Give info to downstream reporters
-	ReportStepStart(executionId uuid.UUID, step cacao.Step, returnVars cacao.Variables)
-	ReportStepEnd(executionId uuid.UUID, step cacao.Step, returnVars cacao.Variables, stepError error)
+	ReportStepStart(executionId uuid.UUID, step cacao.Step, returnVars cacao.Variables, at time.Time)
+	ReportStepEnd(executionId uuid.UUID, step cacao.Step, returnVars cacao.Variables, stepError error, at time.Time)
 }
 
 const MaxReporters int = 10
 
 // TODO:
 // - DONE remove sync wait group mechanisms
-// - add reported_started_on, reported_ended_on
-// - change reporting interface to pass in-code start and end time, to be
-//		collected before reporting function invocation
-// - remove constraint of updating step only if workflow still ongoing
-// - perhaps still add constrain of reporting rimeout.
-// - update documentation
+// - DONE change reporting interface to pass in-code start and end time
+// - DONE remove constraint of updating step only if workflow still ongoing
 // - update tests
 
 // High-level reporter class with injection of specific reporters
@@ -73,56 +70,56 @@ func (reporter *Reporter) RegisterReporters(reporters []downstreamReporter.IDown
 
 // ######################## IWorkflowReporter interface
 
-func (reporter *Reporter) reportWorkflowStart(executionId uuid.UUID, playbook cacao.Playbook) {
+func (reporter *Reporter) reportWorkflowStart(executionId uuid.UUID, playbook cacao.Playbook, at time.Time) {
 	for _, rep := range reporter.reporters {
-		err := rep.ReportWorkflowStart(executionId, playbook)
+		err := rep.ReportWorkflowStart(executionId, playbook, at)
 		if err != nil {
 			log.Warning(err)
 		}
 	}
 }
-func (reporter *Reporter) ReportWorkflowStart(executionId uuid.UUID, playbook cacao.Playbook) {
+func (reporter *Reporter) ReportWorkflowStart(executionId uuid.UUID, playbook cacao.Playbook, at time.Time) {
 	log.Trace(fmt.Sprintf("[execution: %s, playbook: %s] reporting workflow start", executionId, playbook.ID))
-	go reporter.reportWorkflowStart(executionId, playbook)
+	go reporter.reportWorkflowStart(executionId, playbook, at)
 }
 
-func (reporter *Reporter) reportWorkflowEnd(executionId uuid.UUID, playbook cacao.Playbook, workflowError error) {
+func (reporter *Reporter) reportWorkflowEnd(executionId uuid.UUID, playbook cacao.Playbook, workflowError error, at time.Time) {
 	for _, rep := range reporter.reporters {
-		err := rep.ReportWorkflowEnd(executionId, playbook, workflowError)
+		err := rep.ReportWorkflowEnd(executionId, playbook, workflowError, at)
 		if err != nil {
 			log.Warning(err)
 		}
 	}
 }
-func (reporter *Reporter) ReportWorkflowEnd(executionId uuid.UUID, playbook cacao.Playbook, workflowError error) {
+func (reporter *Reporter) ReportWorkflowEnd(executionId uuid.UUID, playbook cacao.Playbook, workflowError error, at time.Time) {
 	log.Trace(fmt.Sprintf("[execution: %s, playbook: %s] reporting workflow end", executionId, playbook.ID))
-	go reporter.reportWorkflowEnd(executionId, playbook, workflowError)
+	go reporter.reportWorkflowEnd(executionId, playbook, workflowError, at)
 }
 
 // ######################## IStepReporter interface
 
-func (reporter *Reporter) reporStepStart(executionId uuid.UUID, step cacao.Step, returnVars cacao.Variables) {
+func (reporter *Reporter) reporStepStart(executionId uuid.UUID, step cacao.Step, returnVars cacao.Variables, at time.Time) {
 	for _, rep := range reporter.reporters {
-		err := rep.ReportStepStart(executionId, step, returnVars)
+		err := rep.ReportStepStart(executionId, step, returnVars, at)
 		if err != nil {
 			log.Warning(err)
 		}
 	}
 }
-func (reporter *Reporter) ReportStepStart(executionId uuid.UUID, step cacao.Step, returnVars cacao.Variables) {
+func (reporter *Reporter) ReportStepStart(executionId uuid.UUID, step cacao.Step, returnVars cacao.Variables, at time.Time) {
 	log.Trace(fmt.Sprintf("[execution: %s, step: %s] reporting step start", executionId, step.ID))
-	go reporter.reporStepStart(executionId, step, returnVars)
+	go reporter.reporStepStart(executionId, step, returnVars, at)
 }
 
-func (reporter *Reporter) reportStepEnd(executionId uuid.UUID, step cacao.Step, returnVars cacao.Variables, stepError error) {
+func (reporter *Reporter) reportStepEnd(executionId uuid.UUID, step cacao.Step, returnVars cacao.Variables, stepError error, at time.Time) {
 	for _, rep := range reporter.reporters {
-		err := rep.ReportStepEnd(executionId, step, returnVars, stepError)
+		err := rep.ReportStepEnd(executionId, step, returnVars, stepError, at)
 		if err != nil {
 			log.Warning(err)
 		}
 	}
 }
-func (reporter *Reporter) ReportStepEnd(executionId uuid.UUID, step cacao.Step, returnVars cacao.Variables, stepError error) {
+func (reporter *Reporter) ReportStepEnd(executionId uuid.UUID, step cacao.Step, returnVars cacao.Variables, stepError error, at time.Time) {
 	log.Trace(fmt.Sprintf("[execution: %s, step: %s] reporting step end", executionId, step.ID))
-	go reporter.reportStepEnd(executionId, step, returnVars, stepError)
+	go reporter.reportStepEnd(executionId, step, returnVars, stepError, at)
 }

--- a/test/unittest/decomposer/decomposer_test.go
+++ b/test/unittest/decomposer/decomposer_test.go
@@ -107,9 +107,14 @@ func TestExecutePlaybook(t *testing.T) {
 		Variables: cacao.NewVariables(expectedVariables),
 	}
 
-	mock_reporter.On("ReportWorkflowStart", executionId, playbook).Return()
+	layout := "2006-01-02T15:04:05.000Z"
+	str := "2014-11-12T11:45:26.371Z"
+	timeNow, _ := time.Parse(layout, str)
+	mock_time.On("Now").Return(timeNow)
+
+	mock_reporter.On("ReportWorkflowStart", executionId, playbook, timeNow).Return()
 	mock_time.On("Sleep", time.Millisecond*10).Return()
-	mock_reporter.On("ReportWorkflowEnd", executionId, playbook, nil).Return()
+	mock_reporter.On("ReportWorkflowEnd", executionId, playbook, nil, timeNow).Return()
 	mock_action_executor.On("Execute", metaStep1, playbookStepMetadata).Return(cacao.NewVariables(cacao.Variable{Name: "return", Value: "value"}), nil)
 
 	details, err := decomposer.Execute(playbook)
@@ -245,9 +250,14 @@ func TestExecutePlaybookMultiStep(t *testing.T) {
 		Variables: cacao.NewVariables(expectedVariables),
 	}
 
-	mock_reporter.On("ReportWorkflowStart", executionId, playbook).Return()
+	layout := "2006-01-02T15:04:05.000Z"
+	str := "2014-11-12T11:45:26.371Z"
+	timeNow, _ := time.Parse(layout, str)
+	mock_time.On("Now").Return(timeNow)
+
+	mock_reporter.On("ReportWorkflowStart", executionId, playbook, timeNow).Return()
 	mock_time.On("Sleep", time.Millisecond*0).Return()
-	mock_reporter.On("ReportWorkflowEnd", executionId, playbook, nil).Return()
+	mock_reporter.On("ReportWorkflowEnd", executionId, playbook, nil, timeNow).Return()
 	mock_action_executor.On("Execute", metaStep1, playbookStepMetadata1).Return(cacao.NewVariables(firstResult), nil)
 
 	playbookStepMetadata2 := action.PlaybookStepMetadata{
@@ -336,9 +346,14 @@ func TestExecuteEmptyMultiStep(t *testing.T) {
 	id, _ := uuid.Parse("6ba7b810-9dad-11d1-80b4-00c04fd430c8")
 	uuid_mock2.On("New").Return(id)
 
-	mock_reporter.On("ReportWorkflowStart", id, playbook).Return()
+	layout := "2006-01-02T15:04:05.000Z"
+	str := "2014-11-12T11:45:26.371Z"
+	timeNow, _ := time.Parse(layout, str)
+	mock_time.On("Now").Return(timeNow)
+
+	mock_reporter.On("ReportWorkflowStart", id, playbook, timeNow).Return()
 	mock_time.On("Sleep", time.Millisecond*0).Return()
-	mock_reporter.On("ReportWorkflowEnd", id, playbook, errors.New("empty success step")).Return()
+	mock_reporter.On("ReportWorkflowEnd", id, playbook, errors.New("empty success step"), timeNow).Return()
 
 	returnedId, err := decomposer2.Execute(playbook)
 	uuid_mock2.AssertExpectations(t)
@@ -397,11 +412,16 @@ func TestExecuteIllegalMultiStep(t *testing.T) {
 		Workflow: map[string]cacao.Step{step1.ID: step1},
 	}
 
+	layout := "2006-01-02T15:04:05.000Z"
+	str := "2014-11-12T11:45:26.371Z"
+	timeNow, _ := time.Parse(layout, str)
+	mock_time.On("Now").Return(timeNow)
+
 	id, _ := uuid.Parse("6ba7b810-9dad-11d1-80b4-00c04fd430c8")
 	uuid_mock2.On("New").Return(id)
-	mock_reporter.On("ReportWorkflowStart", id, playbook).Return()
+	mock_reporter.On("ReportWorkflowStart", id, playbook, timeNow).Return()
 	mock_time.On("Sleep", time.Millisecond*0).Return()
-	mock_reporter.On("ReportWorkflowEnd", id, playbook, errors.New("empty success step")).Return()
+	mock_reporter.On("ReportWorkflowEnd", id, playbook, errors.New("empty success step"), timeNow).Return()
 
 	returnedId, err := decomposer2.Execute(playbook)
 	uuid_mock2.AssertExpectations(t)
@@ -458,10 +478,15 @@ func TestExecutePlaybookAction(t *testing.T) {
 	executionId, _ := uuid.Parse("6ba7b810-9dad-11d1-80b4-00c04fd430c8")
 	metaStep1 := execution.Metadata{ExecutionId: executionId, PlaybookId: "test", StepId: step1.ID}
 
+	layout := "2006-01-02T15:04:05.000Z"
+	str := "2014-11-12T11:45:26.371Z"
+	timeNow, _ := time.Parse(layout, str)
+	mock_time.On("Now").Return(timeNow)
+
 	uuid_mock.On("New").Return(executionId)
-	mock_reporter.On("ReportWorkflowStart", executionId, playbook).Return()
+	mock_reporter.On("ReportWorkflowStart", executionId, playbook, timeNow).Return()
 	mock_time.On("Sleep", time.Millisecond*0).Return()
-	mock_reporter.On("ReportWorkflowEnd", executionId, playbook, nil).Return()
+	mock_reporter.On("ReportWorkflowEnd", executionId, playbook, nil, timeNow).Return()
 
 	mock_playbook_action_executor.On("Execute",
 		metaStep1,
@@ -606,11 +631,16 @@ func TestExecuteIfCondition(t *testing.T) {
 		TargetDefinitions: map[string]cacao.AgentTarget{expectedTarget.ID: expectedTarget},
 	}
 
+	layout := "2006-01-02T15:04:05.000Z"
+	str := "2014-11-12T11:45:26.371Z"
+	timeNow, _ := time.Parse(layout, str)
+	mock_time.On("Now").Return(timeNow)
+
 	executionId, _ := uuid.Parse("6ba7b810-9dad-11d1-80b4-00c04fd430c8")
 	metaStepIf := execution.Metadata{ExecutionId: executionId, PlaybookId: "test", StepId: stepIf.ID}
 
 	uuid_mock.On("New").Return(executionId)
-	mock_reporter.On("ReportWorkflowStart", executionId, playbook).Return()
+	mock_reporter.On("ReportWorkflowStart", executionId, playbook, timeNow).Return()
 	mock_time.On("Sleep", time.Millisecond*0).Return()
 
 	mock_condition_executor.On("Execute",
@@ -647,7 +677,7 @@ func TestExecuteIfCondition(t *testing.T) {
 	mock_action_executor.On("Execute",
 		metaStepCompletion,
 		stepCompletionDetails).Return(cacao.NewVariables(), nil)
-	mock_reporter.On("ReportWorkflowEnd", executionId, playbook, nil).Return()
+	mock_reporter.On("ReportWorkflowEnd", executionId, playbook, nil, timeNow).Return()
 	details, err := decomposer.Execute(playbook)
 	uuid_mock.AssertExpectations(t)
 	fmt.Println(err)

--- a/test/unittest/executor/playbook_action/playbook_action_executor_test.go
+++ b/test/unittest/executor/playbook_action/playbook_action_executor_test.go
@@ -2,6 +2,7 @@ package playbook_action_executor_test
 
 import (
 	"testing"
+	"time"
 
 	"soarca/internal/decomposer"
 	"soarca/internal/executors/playbook_action"
@@ -10,6 +11,7 @@ import (
 	"soarca/test/unittest/mocks/mock_decomposer"
 	mocks_playbook_test "soarca/test/unittest/mocks/mock_playbook_database"
 	"soarca/test/unittest/mocks/mock_reporter"
+	mock_time "soarca/test/unittest/mocks/mock_utils/time"
 
 	"soarca/models/cacao"
 	"soarca/models/execution"
@@ -23,11 +25,12 @@ func TestExecutePlaybook(t *testing.T) {
 	playbookRepoMock := new(mocks_playbook_test.MockPlaybook)
 	mockDecomposer := new(mock_decomposer.Mock_Decomposer)
 	mock_reporter := new(mock_reporter.Mock_Reporter)
+	mock_time := new(mock_time.MockTime)
 
 	controller := new(mock_decomposer_controller.Mock_Controller)
 	database := new(mock_database_controller.Mock_Controller)
 
-	executerObject := playbook_action.New(controller, database, mock_reporter)
+	executerObject := playbook_action.New(controller, database, mock_reporter, mock_time)
 	executionId, _ := uuid.Parse("6ba7b810-9dad-11d1-80b4-00c04fd430c8")
 	playbookId := "playbook--d09351a2-a075-40c8-8054-0b7c423db83f"
 	stepId := "step--81eff59f-d084-4324-9e0a-59e353dbd28f"
@@ -66,11 +69,16 @@ func TestExecutePlaybook(t *testing.T) {
 		PlaybookID:  playbookId,
 	}
 
+	layout := "2006-01-02T15:04:05.000Z"
+	str := "2014-11-12T11:45:26.371Z"
+	timeNow, _ := time.Parse(layout, str)
+	mock_time.On("Now").Return(timeNow)
+
 	database.On("GetDatabaseInstance").Return(playbookRepoMock)
 	controller.On("NewDecomposer").Return(mockDecomposer)
 
-	mock_reporter.On("ReportStepStart", executionId, step, cacao.NewVariables(addedVariables)).Return()
-	mock_reporter.On("ReportStepEnd", executionId, step, cacao.NewVariables(returnedVariables), nil).Return()
+	mock_reporter.On("ReportStepStart", executionId, step, cacao.NewVariables(addedVariables), timeNow).Return()
+	mock_reporter.On("ReportStepEnd", executionId, step, cacao.NewVariables(returnedVariables), nil, timeNow).Return()
 
 	playbook := cacao.Playbook{ID: playbookId, PlaybookVariables: cacao.NewVariables(initialVariables)}
 	playbookRepoMock.On("Read", playbookId).Return(playbook, nil)
@@ -86,6 +94,7 @@ func TestExecutePlaybook(t *testing.T) {
 
 	mockDecomposer.AssertExpectations(t)
 	mock_reporter.AssertExpectations(t)
+	mock_time.AssertExpectations(t)
 	assert.Equal(t, err, nil)
 	assert.Equal(t, results, cacao.NewVariables(returnedVariables))
 

--- a/test/unittest/mocks/mock_reporter/mock_downstream_reporter.go
+++ b/test/unittest/mocks/mock_reporter/mock_downstream_reporter.go
@@ -3,6 +3,7 @@ package mock_reporter
 import (
 	"soarca/models/cacao"
 	"sync"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/mock"
@@ -13,24 +14,24 @@ type Mock_Downstream_Reporter struct {
 	Wg *sync.WaitGroup
 }
 
-func (ds_reporter *Mock_Downstream_Reporter) ReportWorkflowStart(executionId uuid.UUID, playbook cacao.Playbook) error {
+func (ds_reporter *Mock_Downstream_Reporter) ReportWorkflowStart(executionId uuid.UUID, playbook cacao.Playbook, at time.Time) error {
 	defer ds_reporter.Wg.Done()
-	args := ds_reporter.Called(executionId, playbook)
+	args := ds_reporter.Called(executionId, playbook, at)
 	return args.Error(0)
 }
-func (ds_reporter *Mock_Downstream_Reporter) ReportWorkflowEnd(executionId uuid.UUID, playbook cacao.Playbook, workflowError error) error {
+func (ds_reporter *Mock_Downstream_Reporter) ReportWorkflowEnd(executionId uuid.UUID, playbook cacao.Playbook, workflowError error, at time.Time) error {
 	defer ds_reporter.Wg.Done()
-	args := ds_reporter.Called(executionId, playbook, workflowError)
+	args := ds_reporter.Called(executionId, playbook, workflowError, at)
 	return args.Error(0)
 }
 
-func (ds_reporter *Mock_Downstream_Reporter) ReportStepStart(executionId uuid.UUID, step cacao.Step, stepResults cacao.Variables) error {
+func (ds_reporter *Mock_Downstream_Reporter) ReportStepStart(executionId uuid.UUID, step cacao.Step, stepResults cacao.Variables, at time.Time) error {
 	defer ds_reporter.Wg.Done()
-	args := ds_reporter.Called(executionId, step, stepResults)
+	args := ds_reporter.Called(executionId, step, stepResults, at)
 	return args.Error(0)
 }
-func (ds_reporter *Mock_Downstream_Reporter) ReportStepEnd(executionId uuid.UUID, step cacao.Step, stepResults cacao.Variables, stepError error) error {
+func (ds_reporter *Mock_Downstream_Reporter) ReportStepEnd(executionId uuid.UUID, step cacao.Step, stepResults cacao.Variables, stepError error, at time.Time) error {
 	defer ds_reporter.Wg.Done()
-	args := ds_reporter.Called(executionId, step, stepResults, stepError)
+	args := ds_reporter.Called(executionId, step, stepResults, stepError, at)
 	return args.Error(0)
 }

--- a/test/unittest/mocks/mock_reporter/mock_reporter.go
+++ b/test/unittest/mocks/mock_reporter/mock_reporter.go
@@ -2,6 +2,7 @@ package mock_reporter
 
 import (
 	"soarca/models/cacao"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/mock"
@@ -11,16 +12,16 @@ type Mock_Reporter struct {
 	mock.Mock
 }
 
-func (reporter *Mock_Reporter) ReportWorkflowStart(executionId uuid.UUID, playbook cacao.Playbook) {
-	_ = reporter.Called(executionId, playbook)
+func (reporter *Mock_Reporter) ReportWorkflowStart(executionId uuid.UUID, playbook cacao.Playbook, at time.Time) {
+	_ = reporter.Called(executionId, playbook, at)
 }
-func (reporter *Mock_Reporter) ReportWorkflowEnd(executionId uuid.UUID, playbook cacao.Playbook, err error) {
-	_ = reporter.Called(executionId, playbook, err)
+func (reporter *Mock_Reporter) ReportWorkflowEnd(executionId uuid.UUID, playbook cacao.Playbook, err error, at time.Time) {
+	_ = reporter.Called(executionId, playbook, err, at)
 }
 
-func (reporter *Mock_Reporter) ReportStepStart(executionId uuid.UUID, step cacao.Step, returnVars cacao.Variables) {
-	_ = reporter.Called(executionId, step, returnVars)
+func (reporter *Mock_Reporter) ReportStepStart(executionId uuid.UUID, step cacao.Step, returnVars cacao.Variables, at time.Time) {
+	_ = reporter.Called(executionId, step, returnVars, at)
 }
-func (reporter *Mock_Reporter) ReportStepEnd(executionId uuid.UUID, step cacao.Step, returnVars cacao.Variables, err error) {
-	_ = reporter.Called(executionId, step, returnVars, err)
+func (reporter *Mock_Reporter) ReportStepEnd(executionId uuid.UUID, step cacao.Step, returnVars cacao.Variables, err error, at time.Time) {
+	_ = reporter.Called(executionId, step, returnVars, err, at)
 }

--- a/test/unittest/reporters/downstream_reporter/cache_test.go
+++ b/test/unittest/reporters/downstream_reporter/cache_test.go
@@ -878,3 +878,91 @@ func TestInvalidStepReportAfterStepEnd(t *testing.T) {
 	assert.Equal(t, err, expectedErr)
 	mock_time.AssertExpectations(t)
 }
+
+func TestAcceptedStepReportAfterExecutionEnd(t *testing.T) {
+
+	mock_time := new(mock_time.MockTime)
+	cacheReporter := cache.New(mock_time, 10)
+
+	expectedCommand := cacao.Command{
+		Type:    "ssh",
+		Command: "ssh ls -la",
+	}
+
+	expectedVariables := cacao.Variable{
+		Type:  "string",
+		Name:  "var1",
+		Value: "testing",
+	}
+
+	step1 := cacao.Step{
+		Type:          "action",
+		ID:            "action--test",
+		Name:          "ssh-tests",
+		StepVariables: cacao.NewVariables(expectedVariables),
+		Commands:      []cacao.Command{expectedCommand},
+		Cases:         map[string]string{},
+		OnCompletion:  "end--test",
+		Agent:         "agent1",
+		Targets:       []string{"target1"},
+	}
+
+	end := cacao.Step{
+		Type: "end",
+		ID:   "end--test",
+		Name: "end step",
+	}
+
+	expectedAuth := cacao.AuthenticationInformation{
+		Name: "user",
+		ID:   "auth1",
+	}
+
+	expectedTarget := cacao.AgentTarget{
+		Name:               "sometarget",
+		AuthInfoIdentifier: "auth1",
+		ID:                 "target1",
+	}
+
+	expectedAgent := cacao.AgentTarget{
+		Type: "soarca",
+		Name: "soarca-ssh",
+	}
+
+	playbook := cacao.Playbook{
+		ID:                            "test",
+		Type:                          "test",
+		Name:                          "ssh-test",
+		WorkflowStart:                 step1.ID,
+		AuthenticationInfoDefinitions: map[string]cacao.AuthenticationInformation{"id": expectedAuth},
+		AgentDefinitions:              map[string]cacao.AgentTarget{"agent1": expectedAgent},
+		TargetDefinitions:             map[string]cacao.AgentTarget{"target1": expectedTarget},
+
+		Workflow: map[string]cacao.Step{step1.ID: step1, end.ID: end},
+	}
+	executionId0 := uuid.MustParse("6ba7b810-9dad-11d1-80b4-00c04fd430c0")
+	layout := "2006-01-02T15:04:05.000Z"
+	str := "2014-11-12T11:45:26.371Z"
+	timeNow, _ := time.Parse(layout, str)
+	mock_time.On("Now").Return(timeNow)
+
+	err := cacheReporter.ReportWorkflowStart(executionId0, playbook, mock_time.Now())
+	if err != nil {
+		t.Fail()
+	}
+	err = cacheReporter.ReportStepStart(executionId0, step1, cacao.NewVariables(expectedVariables), mock_time.Now())
+	if err != nil {
+		t.Fail()
+	}
+	err = cacheReporter.ReportWorkflowEnd(executionId0, playbook, nil, mock_time.Now())
+	if err != nil {
+		t.Fail()
+	}
+
+	err = cacheReporter.ReportStepEnd(executionId0, step1, cacao.NewVariables(expectedVariables), nil, mock_time.Now())
+	if err != nil {
+		t.Fail()
+	}
+
+	mock_time.AssertExpectations(t)
+}

--- a/test/unittest/reporters/downstream_reporter/cache_test.go
+++ b/test/unittest/reporters/downstream_reporter/cache_test.go
@@ -84,20 +84,20 @@ func TestReportWorkflowStartFirst(t *testing.T) {
 	timeNow, _ := time.Parse(layout, str)
 	mock_time.On("Now").Return(timeNow)
 
-	err := cacheReporter.ReportWorkflowStart(executionId0, playbook)
+	err := cacheReporter.ReportWorkflowStart(executionId0, playbook, mock_time.Now())
 	if err != nil {
 		t.Fail()
 	}
 
 	mock_time.On("Now").Return(timeNow)
 
-	err = cacheReporter.ReportStepStart(executionId0, step1, cacao.NewVariables(expectedVariables))
+	err = cacheReporter.ReportStepStart(executionId0, step1, cacao.NewVariables(expectedVariables), mock_time.Now())
 	if err != nil {
 		t.Fail()
 	}
 
 	mock_time.On("Now").Return(timeNow)
-	err = cacheReporter.ReportStepEnd(executionId0, step1, cacao.NewVariables(), nil)
+	err = cacheReporter.ReportStepEnd(executionId0, step1, cacao.NewVariables(), nil, mock_time.Now())
 	if err != nil {
 		t.Fail()
 	}
@@ -262,15 +262,15 @@ func TestReportWorkflowStartFifo(t *testing.T) {
 		expectedExecutionsFifo = append(expectedExecutionsFifo, entry)
 	}
 
-	err := cacheReporter.ReportWorkflowStart(executionId0, playbook)
+	err := cacheReporter.ReportWorkflowStart(executionId0, playbook, mock_time.Now())
 	if err != nil {
 		t.Fail()
 	}
-	err = cacheReporter.ReportWorkflowStart(executionId1, playbook)
+	err = cacheReporter.ReportWorkflowStart(executionId1, playbook, mock_time.Now())
 	if err != nil {
 		t.Fail()
 	}
-	err = cacheReporter.ReportWorkflowStart(executionId2, playbook)
+	err = cacheReporter.ReportWorkflowStart(executionId2, playbook, mock_time.Now())
 	if err != nil {
 		t.Fail()
 	}
@@ -282,7 +282,7 @@ func TestReportWorkflowStartFifo(t *testing.T) {
 	t.Log(returnedExecutionsFull)
 	assert.Equal(t, expectedExecutionsFull, returnedExecutionsFull)
 
-	err = cacheReporter.ReportWorkflowStart(executionId3, playbook)
+	err = cacheReporter.ReportWorkflowStart(executionId3, playbook, mock_time.Now())
 	if err != nil {
 		t.Fail()
 	}
@@ -362,11 +362,11 @@ func TestReportWorkflowEnd(t *testing.T) {
 	timeNow, _ := time.Parse(layout, str)
 	mock_time.On("Now").Return(timeNow)
 
-	err := cacheReporter.ReportWorkflowStart(executionId0, playbook)
+	err := cacheReporter.ReportWorkflowStart(executionId0, playbook, mock_time.Now())
 	if err != nil {
 		t.Fail()
 	}
-	err = cacheReporter.ReportWorkflowEnd(executionId0, playbook, nil)
+	err = cacheReporter.ReportWorkflowEnd(executionId0, playbook, nil, mock_time.Now())
 	if err != nil {
 		t.Fail()
 	}
@@ -462,11 +462,11 @@ func TestReportStepStartAndEnd(t *testing.T) {
 	timeNow, _ := time.Parse(layout, str)
 	mock_time.On("Now").Return(timeNow)
 
-	err := cacheReporter.ReportWorkflowStart(executionId0, playbook)
+	err := cacheReporter.ReportWorkflowStart(executionId0, playbook, mock_time.Now())
 	if err != nil {
 		t.Fail()
 	}
-	err = cacheReporter.ReportStepStart(executionId0, step1, cacao.NewVariables(expectedVariables))
+	err = cacheReporter.ReportStepStart(executionId0, step1, cacao.NewVariables(expectedVariables), mock_time.Now())
 	if err != nil {
 		t.Fail()
 	}
@@ -492,7 +492,7 @@ func TestReportStepStartAndEnd(t *testing.T) {
 	assert.Equal(t, stepStatus.Error, expectedStepStatus.Error)
 	assert.Equal(t, err, nil)
 
-	err = cacheReporter.ReportStepEnd(executionId0, step1, cacao.NewVariables(expectedVariables), nil)
+	err = cacheReporter.ReportStepEnd(executionId0, step1, cacao.NewVariables(expectedVariables), nil, mock_time.Now())
 	if err != nil {
 		t.Fail()
 	}
@@ -590,11 +590,11 @@ func TestReportStepStartCommandsEncoding(t *testing.T) {
 	timeNow, _ := time.Parse(layout, str)
 	mock_time.On("Now").Return(timeNow)
 
-	err := cacheReporter.ReportWorkflowStart(executionId0, playbook)
+	err := cacheReporter.ReportWorkflowStart(executionId0, playbook, mock_time.Now())
 	if err != nil {
 		t.Fail()
 	}
-	err = cacheReporter.ReportStepStart(executionId0, step1, cacao.NewVariables(expectedVariables))
+	err = cacheReporter.ReportStepStart(executionId0, step1, cacao.NewVariables(expectedVariables), mock_time.Now())
 	if err != nil {
 		t.Fail()
 	}
@@ -632,7 +632,7 @@ func TestReportStepStartCommandsEncoding(t *testing.T) {
 	assert.Equal(t, stepStatus.IsAutomated, expectedStepStatus.IsAutomated)
 	assert.Equal(t, err, nil)
 
-	err = cacheReporter.ReportStepEnd(executionId0, step1, cacao.NewVariables(expectedVariables), nil)
+	err = cacheReporter.ReportStepEnd(executionId0, step1, cacao.NewVariables(expectedVariables), nil, mock_time.Now())
 	if err != nil {
 		t.Fail()
 	}
@@ -726,11 +726,11 @@ func TestReportStepStartManualCommand(t *testing.T) {
 	timeNow, _ := time.Parse(layout, str)
 	mock_time.On("Now").Return(timeNow)
 
-	err := cacheReporter.ReportWorkflowStart(executionId0, playbook)
+	err := cacheReporter.ReportWorkflowStart(executionId0, playbook, mock_time.Now())
 	if err != nil {
 		t.Fail()
 	}
-	err = cacheReporter.ReportStepStart(executionId0, step1, cacao.NewVariables(expectedVariables))
+	err = cacheReporter.ReportStepStart(executionId0, step1, cacao.NewVariables(expectedVariables), mock_time.Now())
 	if err != nil {
 		t.Fail()
 	}
@@ -762,7 +762,7 @@ func TestReportStepStartManualCommand(t *testing.T) {
 	assert.Equal(t, stepStatus.IsAutomated, expectedStepStatus.IsAutomated)
 	assert.Equal(t, err, nil)
 
-	err = cacheReporter.ReportStepEnd(executionId0, step1, cacao.NewVariables(expectedVariables), nil)
+	err = cacheReporter.ReportStepEnd(executionId0, step1, cacao.NewVariables(expectedVariables), nil, mock_time.Now())
 	if err != nil {
 		t.Fail()
 	}
@@ -787,95 +787,6 @@ func TestReportStepStartManualCommand(t *testing.T) {
 	assert.Equal(t, stepResult.Status, expectedStepResult.Status)
 	assert.Equal(t, stepResult.Error, expectedStepResult.Error)
 	assert.Equal(t, err, nil)
-	mock_time.AssertExpectations(t)
-}
-
-func TestInvalidStepReportAfterExecutionEnd(t *testing.T) {
-	mock_time := new(mock_time.MockTime)
-	cacheReporter := cache.New(mock_time, 10)
-
-	expectedCommand := cacao.Command{
-		Type:    "ssh",
-		Command: "ssh ls -la",
-	}
-
-	expectedVariables := cacao.Variable{
-		Type:  "string",
-		Name:  "var1",
-		Value: "testing",
-	}
-
-	step1 := cacao.Step{
-		Type:          "action",
-		ID:            "action--test",
-		Name:          "ssh-tests",
-		StepVariables: cacao.NewVariables(expectedVariables),
-		Commands:      []cacao.Command{expectedCommand},
-		Cases:         map[string]string{},
-		OnCompletion:  "end--test",
-		Agent:         "agent1",
-		Targets:       []string{"target1"},
-	}
-
-	end := cacao.Step{
-		Type: "end",
-		ID:   "end--test",
-		Name: "end step",
-	}
-
-	expectedAuth := cacao.AuthenticationInformation{
-		Name: "user",
-		ID:   "auth1",
-	}
-
-	expectedTarget := cacao.AgentTarget{
-		Name:               "sometarget",
-		AuthInfoIdentifier: "auth1",
-		ID:                 "target1",
-	}
-
-	expectedAgent := cacao.AgentTarget{
-		Type: "soarca",
-		Name: "soarca-ssh",
-	}
-
-	playbook := cacao.Playbook{
-		ID:                            "test",
-		Type:                          "test",
-		Name:                          "ssh-test",
-		WorkflowStart:                 step1.ID,
-		AuthenticationInfoDefinitions: map[string]cacao.AuthenticationInformation{"id": expectedAuth},
-		AgentDefinitions:              map[string]cacao.AgentTarget{"agent1": expectedAgent},
-		TargetDefinitions:             map[string]cacao.AgentTarget{"target1": expectedTarget},
-
-		Workflow: map[string]cacao.Step{step1.ID: step1, end.ID: end},
-	}
-	executionId0 := uuid.MustParse("6ba7b810-9dad-11d1-80b4-00c04fd430c0")
-	layout := "2006-01-02T15:04:05.000Z"
-	str := "2014-11-12T11:45:26.371Z"
-	timeNow, _ := time.Parse(layout, str)
-	mock_time.On("Now").Return(timeNow)
-
-	err := cacheReporter.ReportWorkflowStart(executionId0, playbook)
-	if err != nil {
-		t.Fail()
-	}
-	err = cacheReporter.ReportStepStart(executionId0, step1, cacao.NewVariables(expectedVariables))
-	if err != nil {
-		t.Fail()
-	}
-	err = cacheReporter.ReportWorkflowEnd(executionId0, playbook, nil)
-	if err != nil {
-		t.Fail()
-	}
-
-	err = cacheReporter.ReportStepEnd(executionId0, step1, cacao.NewVariables(expectedVariables), nil)
-	if err == nil {
-		t.Fail()
-	}
-
-	expectedErr := errors.New("trying to report on the execution of a step for an already reportedly terminated playbook execution")
-	assert.Equal(t, err, expectedErr)
 	mock_time.AssertExpectations(t)
 }
 
@@ -945,20 +856,20 @@ func TestInvalidStepReportAfterStepEnd(t *testing.T) {
 	timeNow, _ := time.Parse(layout, str)
 	mock_time.On("Now").Return(timeNow)
 
-	err := cacheReporter.ReportWorkflowStart(executionId0, playbook)
+	err := cacheReporter.ReportWorkflowStart(executionId0, playbook, mock_time.Now())
 	if err != nil {
 		t.Fail()
 	}
-	err = cacheReporter.ReportStepStart(executionId0, step1, cacao.NewVariables(expectedVariables))
+	err = cacheReporter.ReportStepStart(executionId0, step1, cacao.NewVariables(expectedVariables), mock_time.Now())
 	if err != nil {
 		t.Fail()
 	}
-	err = cacheReporter.ReportStepEnd(executionId0, step1, cacao.NewVariables(expectedVariables), nil)
+	err = cacheReporter.ReportStepEnd(executionId0, step1, cacao.NewVariables(expectedVariables), nil, mock_time.Now())
 	if err != nil {
 		t.Fail()
 	}
 
-	err = cacheReporter.ReportStepEnd(executionId0, step1, cacao.NewVariables(expectedVariables), nil)
+	err = cacheReporter.ReportStepEnd(executionId0, step1, cacao.NewVariables(expectedVariables), nil, mock_time.Now())
 	if err == nil {
 		t.Fail()
 	}

--- a/test/unittest/reporters/reporter/reporter_test.go
+++ b/test/unittest/reporters/reporter/reporter_test.go
@@ -6,8 +6,10 @@ import (
 	ds_reporter "soarca/internal/reporter/downstream_reporter"
 	"soarca/models/cacao"
 	"soarca/test/unittest/mocks/mock_reporter"
+	mock_time "soarca/test/unittest/mocks/mock_utils/time"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/go-playground/assert/v2"
 	"github.com/google/uuid"
@@ -43,6 +45,7 @@ func TestReportWorkflowStart(t *testing.T) {
 	var wg sync.WaitGroup
 	mock_ds_reporter := mock_reporter.Mock_Downstream_Reporter{Wg: &wg}
 	reporter := reporter.New([]ds_reporter.IDownStreamReporter{&mock_ds_reporter})
+	mock_time := new(mock_time.MockTime)
 
 	expectedCommand := cacao.Command{
 		Type:    "ssh",
@@ -103,18 +106,25 @@ func TestReportWorkflowStart(t *testing.T) {
 
 	executionId, _ := uuid.Parse("6ba7b810-9dad-11d1-80b4-00c04fd430c8")
 
+	layout := "2006-01-02T15:04:05.000Z"
+	str := "2014-11-12T11:45:26.371Z"
+	timeNow, _ := time.Parse(layout, str)
+	mock_time.On("Now").Return(timeNow)
+
 	wg.Add(1)
-	mock_ds_reporter.On("ReportWorkflowStart", executionId, playbook).Return(nil)
-	reporter.ReportWorkflowStart(executionId, playbook)
+	mock_ds_reporter.On("ReportWorkflowStart", executionId, playbook, timeNow).Return(nil)
+	reporter.ReportWorkflowStart(executionId, playbook, mock_time.Now())
 
 	wg.Wait()
 	mock_ds_reporter.AssertExpectations(t)
+	mock_time.AssertExpectations(t)
 }
 
 func TestReportWorkflowEnd(t *testing.T) {
 	var wg sync.WaitGroup
 	mock_ds_reporter := mock_reporter.Mock_Downstream_Reporter{Wg: &wg}
 	reporter := reporter.New([]ds_reporter.IDownStreamReporter{&mock_ds_reporter})
+	mock_time := new(mock_time.MockTime)
 
 	expectedCommand := cacao.Command{
 		Type:    "ssh",
@@ -175,18 +185,25 @@ func TestReportWorkflowEnd(t *testing.T) {
 
 	executionId, _ := uuid.Parse("6ba7b810-9dad-11d1-80b4-00c04fd430c8")
 
+	layout := "2006-01-02T15:04:05.000Z"
+	str := "2014-11-12T11:45:26.371Z"
+	timeNow, _ := time.Parse(layout, str)
+	mock_time.On("Now").Return(timeNow)
+
 	wg.Add(1)
-	mock_ds_reporter.On("ReportWorkflowEnd", executionId, playbook, nil).Return(nil)
-	reporter.ReportWorkflowEnd(executionId, playbook, nil)
+	mock_ds_reporter.On("ReportWorkflowEnd", executionId, playbook, nil, timeNow).Return(nil)
+	reporter.ReportWorkflowEnd(executionId, playbook, nil, mock_time.Now())
 
 	wg.Wait()
 	mock_ds_reporter.AssertExpectations(t)
+	mock_time.AssertExpectations(t)
 }
 
 func TestReportStepStart(t *testing.T) {
 	var wg sync.WaitGroup
 	mock_ds_reporter := mock_reporter.Mock_Downstream_Reporter{Wg: &wg}
 	reporter := reporter.New([]ds_reporter.IDownStreamReporter{&mock_ds_reporter})
+	mock_time := new(mock_time.MockTime)
 
 	expectedCommand := cacao.Command{
 		Type:    "ssh",
@@ -213,9 +230,14 @@ func TestReportStepStart(t *testing.T) {
 
 	executionId, _ := uuid.Parse("6ba7b810-9dad-11d1-80b4-00c04fd430c8")
 
+	layout := "2006-01-02T15:04:05.000Z"
+	str := "2014-11-12T11:45:26.371Z"
+	timeNow, _ := time.Parse(layout, str)
+	mock_time.On("Now").Return(timeNow)
+
 	wg.Add(1)
-	mock_ds_reporter.On("ReportStepStart", executionId, step1, cacao.NewVariables(expectedVariables)).Return(nil)
-	reporter.ReportStepStart(executionId, step1, cacao.NewVariables(expectedVariables))
+	mock_ds_reporter.On("ReportStepStart", executionId, step1, cacao.NewVariables(expectedVariables), timeNow).Return(nil)
+	reporter.ReportStepStart(executionId, step1, cacao.NewVariables(expectedVariables), mock_time.Now())
 
 	wg.Wait()
 	mock_ds_reporter.AssertExpectations(t)
@@ -225,6 +247,7 @@ func TestReportStepEnd(t *testing.T) {
 	var wg sync.WaitGroup
 	mock_ds_reporter := mock_reporter.Mock_Downstream_Reporter{Wg: &wg}
 	reporter := reporter.New([]ds_reporter.IDownStreamReporter{&mock_ds_reporter})
+	mock_time := new(mock_time.MockTime)
 
 	expectedCommand := cacao.Command{
 		Type:    "ssh",
@@ -251,12 +274,18 @@ func TestReportStepEnd(t *testing.T) {
 
 	executionId, _ := uuid.Parse("6ba7b810-9dad-11d1-80b4-00c04fd430c8")
 
+	layout := "2006-01-02T15:04:05.000Z"
+	str := "2014-11-12T11:45:26.371Z"
+	timeNow, _ := time.Parse(layout, str)
+	mock_time.On("Now").Return(timeNow)
+
 	wg.Add(1)
-	mock_ds_reporter.On("ReportStepEnd", executionId, step1, cacao.NewVariables(expectedVariables), nil).Return(nil)
-	reporter.ReportStepEnd(executionId, step1, cacao.NewVariables(expectedVariables), nil)
+	mock_ds_reporter.On("ReportStepEnd", executionId, step1, cacao.NewVariables(expectedVariables), nil, timeNow).Return(nil)
+	reporter.ReportStepEnd(executionId, step1, cacao.NewVariables(expectedVariables), nil, mock_time.Now())
 
 	wg.Wait()
 	mock_ds_reporter.AssertExpectations(t)
+	mock_time.AssertExpectations(t)
 }
 
 func TestMultipleDownstreamReporters(t *testing.T) {
@@ -264,6 +293,8 @@ func TestMultipleDownstreamReporters(t *testing.T) {
 	mock_ds_reporter1 := mock_reporter.Mock_Downstream_Reporter{Wg: &wg}
 	mock_ds_reporter2 := mock_reporter.Mock_Downstream_Reporter{Wg: &wg}
 	reporter := reporter.New([]ds_reporter.IDownStreamReporter{&mock_ds_reporter1, &mock_ds_reporter2})
+	mock_time := new(mock_time.MockTime)
+
 	expectedCommand := cacao.Command{
 		Type:    "ssh",
 		Command: "ssh ls -la",
@@ -323,28 +354,34 @@ func TestMultipleDownstreamReporters(t *testing.T) {
 
 	executionId, _ := uuid.Parse("6ba7b810-9dad-11d1-80b4-00c04fd430c8")
 
-	wg.Add(2)
-	mock_ds_reporter1.On("ReportWorkflowStart", executionId, playbook).Return(nil)
-	mock_ds_reporter2.On("ReportWorkflowStart", executionId, playbook).Return(nil)
+	layout := "2006-01-02T15:04:05.000Z"
+	str := "2014-11-12T11:45:26.371Z"
+	timeNow, _ := time.Parse(layout, str)
+	mock_time.On("Now").Return(timeNow)
 
 	wg.Add(2)
-	mock_ds_reporter1.On("ReportStepStart", executionId, step1, cacao.NewVariables(expectedVariables)).Return(nil)
-	mock_ds_reporter2.On("ReportStepStart", executionId, step1, cacao.NewVariables(expectedVariables)).Return(nil)
+	mock_ds_reporter1.On("ReportWorkflowStart", executionId, playbook, timeNow).Return(nil)
+	mock_ds_reporter2.On("ReportWorkflowStart", executionId, playbook, timeNow).Return(nil)
 
 	wg.Add(2)
-	mock_ds_reporter1.On("ReportStepEnd", executionId, step1, cacao.NewVariables(expectedVariables), nil).Return(nil)
-	mock_ds_reporter2.On("ReportStepEnd", executionId, step1, cacao.NewVariables(expectedVariables), nil).Return(nil)
+	mock_ds_reporter1.On("ReportStepStart", executionId, step1, cacao.NewVariables(expectedVariables), timeNow).Return(nil)
+	mock_ds_reporter2.On("ReportStepStart", executionId, step1, cacao.NewVariables(expectedVariables), timeNow).Return(nil)
 
 	wg.Add(2)
-	mock_ds_reporter1.On("ReportWorkflowEnd", executionId, playbook, nil).Return(nil)
-	mock_ds_reporter2.On("ReportWorkflowEnd", executionId, playbook, nil).Return(nil)
+	mock_ds_reporter1.On("ReportStepEnd", executionId, step1, cacao.NewVariables(expectedVariables), nil, timeNow).Return(nil)
+	mock_ds_reporter2.On("ReportStepEnd", executionId, step1, cacao.NewVariables(expectedVariables), nil, timeNow).Return(nil)
 
-	reporter.ReportWorkflowStart(executionId, playbook)
-	reporter.ReportStepStart(executionId, step1, cacao.NewVariables(expectedVariables))
-	reporter.ReportStepEnd(executionId, step1, cacao.NewVariables(expectedVariables), nil)
-	reporter.ReportWorkflowEnd(executionId, playbook, nil)
+	wg.Add(2)
+	mock_ds_reporter1.On("ReportWorkflowEnd", executionId, playbook, nil, timeNow).Return(nil)
+	mock_ds_reporter2.On("ReportWorkflowEnd", executionId, playbook, nil, timeNow).Return(nil)
+
+	reporter.ReportWorkflowStart(executionId, playbook, mock_time.Now())
+	reporter.ReportStepStart(executionId, step1, cacao.NewVariables(expectedVariables), mock_time.Now())
+	reporter.ReportStepEnd(executionId, step1, cacao.NewVariables(expectedVariables), nil, mock_time.Now())
+	reporter.ReportWorkflowEnd(executionId, playbook, nil, mock_time.Now())
 
 	wg.Wait()
 	mock_ds_reporter1.AssertExpectations(t)
 	mock_ds_reporter2.AssertExpectations(t)
+	mock_time.AssertExpectations(t)
 }

--- a/test/unittest/routes/reporter_api/reporter_api_test.go
+++ b/test/unittest/routes/reporter_api/reporter_api_test.go
@@ -120,16 +120,16 @@ func TestGetExecutions(t *testing.T) {
 		expectedExecutionsReport = append(expectedExecutionsReport, entry)
 	}
 
-	err := cacheReporter.ReportWorkflowStart(executionId0, playbook)
+	err := cacheReporter.ReportWorkflowStart(executionId0, playbook, mock_time.Now())
 	if err != nil {
 		t.Fail()
 	}
 
-	err = cacheReporter.ReportWorkflowStart(executionId1, playbook)
+	err = cacheReporter.ReportWorkflowStart(executionId1, playbook, mock_time.Now())
 	if err != nil {
 		t.Fail()
 	}
-	err = cacheReporter.ReportWorkflowStart(executionId2, playbook)
+	err = cacheReporter.ReportWorkflowStart(executionId2, playbook, mock_time.Now())
 	if err != nil {
 		t.Fail()
 	}
@@ -231,24 +231,24 @@ func TestGetExecutionReport(t *testing.T) {
 	timeNow, _ := time.Parse(layout, str)
 	mock_time.On("Now").Return(timeNow)
 
-	err := cacheReporter.ReportWorkflowStart(executionId0, playbook)
+	err := cacheReporter.ReportWorkflowStart(executionId0, playbook, mock_time.Now())
 	if err != nil {
 		t.Fail()
 	}
-	err = cacheReporter.ReportStepStart(executionId0, step1, cacao.NewVariables(expectedVariables))
+	err = cacheReporter.ReportStepStart(executionId0, step1, cacao.NewVariables(expectedVariables), mock_time.Now())
 	if err != nil {
 		t.Fail()
 	}
 
-	err = cacheReporter.ReportWorkflowStart(executionId1, playbook)
+	err = cacheReporter.ReportWorkflowStart(executionId1, playbook, mock_time.Now())
 	if err != nil {
 		t.Fail()
 	}
-	err = cacheReporter.ReportWorkflowStart(executionId2, playbook)
+	err = cacheReporter.ReportWorkflowStart(executionId2, playbook, mock_time.Now())
 	if err != nil {
 		t.Fail()
 	}
-	err = cacheReporter.ReportStepEnd(executionId0, step1, cacao.NewVariables(expectedVariables), nil)
+	err = cacheReporter.ReportStepEnd(executionId0, step1, cacao.NewVariables(expectedVariables), nil, mock_time.Now())
 	if err != nil {
 		t.Fail()
 	}


### PR DESCRIPTION
Added a sync.WaitGroup to the reporter module, which is used to ensure that the routine that reports the workflow end wg.Wait()-s before executing, allowing for all other reporting subroutines to record the progress correctly.

Note: I don't know if this can be unit-tested.