### PR TITLE
fix caldera capability name

### DIFF
--- a/internal/capability/caldera/caldera.go
+++ b/internal/capability/caldera/caldera.go
@@ -1,0 +1,47 @@
+package caldera
+
+import (
+	"reflect"
+
+	"soarca/logger"
+	"soarca/models/cacao"
+	"soarca/models/execution"
+)
+
+type calderaCapability struct{}
+
+type Empty struct{}
+
+const (
+	calderaResult  = "__soarca_caldera_result__"
+	calderaError   = "__soarca_caldera_error__"
+	capabilityName = "soarca-caldera"
+)
+
+var (
+	component = reflect.TypeOf(Empty{}).PkgPath()
+	log       *logger.Log
+)
+
+func init() {
+	log = logger.Logger(component, logger.Info, "", logger.Json)
+}
+
+func New() *calderaCapability {
+	return &calderaCapability{}
+}
+
+func (capability *calderaCapability) GetType() string {
+	return capabilityName
+}
+
+func (capability *calderaCapability) Execute(
+	metadata execution.Metadata,
+	command cacao.Command,
+	authentication cacao.AuthenticationInformation,
+	target cacao.AgentTarget,
+	variables cacao.Variables) (cacao.Variables, error) {
+
+	log.Info("Successfully called execute on the caldera capability")
+	return cacao.NewVariables(), nil
+}

--- a/internal/capability/caldera/caldera.go
+++ b/internal/capability/caldera/caldera.go
@@ -13,9 +13,9 @@ type calderaCapability struct{}
 type Empty struct{}
 
 const (
-	calderaResult  = "__soarca_caldera_result__"
-	calderaError   = "__soarca_caldera_error__"
-	capabilityName = "soarca-caldera"
+	calderaResult  = "__soarca_caldera__cmd_result__"
+	calderaError   = "__soarca_caldera_cmd_error__"
+	capabilityName = "soarca-caldera-cmd"
 )
 
 var (

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"soarca/internal/capability"
+	"soarca/internal/capability/caldera"
 	capabilityController "soarca/internal/capability/controller"
 	finExecutor "soarca/internal/capability/fin"
 	"soarca/internal/capability/http"
@@ -73,6 +74,9 @@ func (controller *Controller) NewDecomposer() decomposer.IDecomposer {
 
 	poswershell := powershell.New()
 	capabilities[poswershell.GetType()] = poswershell
+
+	calderaCapability := caldera.New()
+	capabilities[calderaCapability.GetType()] = calderaCapability
 
 	enableFins, _ := strconv.ParseBool(utils.GetEnv("ENABLE_FINS", "false"))
 


### PR DESCRIPTION
The capability is supposed to come from the CACAO `command-type-ov`, which in the case of caldera is `caldera-cmd`.