### PR TITLE
Update swag command in makefile to only consider relevant directories

### DIFF
--- a/makefile
+++ b/makefile
@@ -11,7 +11,7 @@ GOFLAGS = -ldflags "$(GOLDFLAGS)"
 
 swagger:
 	mkdir -p api
-	swag init -g cmd/soarca/main.go -o api
+	swag init -g main.go -o api -d cmd/soarca/,api
 
 lint: swagger
 	


### PR DESCRIPTION
Swagger would previously look at all subdirectories, which did work. When adding a git worktree (i.e. an extra folder not interfering with original source code) this would case a build failure. It also significantly cleans up the make output.